### PR TITLE
fix: resolve condição de corrida no refresh token e previne múltiplos logouts

### DIFF
--- a/src/services/api/AxiosHelper.ts
+++ b/src/services/api/AxiosHelper.ts
@@ -1,6 +1,7 @@
 import type { AxiosError } from "axios";
 import axios from "axios";
 import { notificarErro, notificarInfo } from "../../helpers/Notificacao";
+import { refreshTokenManager } from "../RefreshTokenManager";
 
 interface ApiResultError {
   errors: string[]
@@ -28,7 +29,18 @@ export function CreateIntanceAxios() {
   });
 
   AxiosInstance.interceptors.request.use(
-    (config) => {
+    async (config) => {
+      try {
+        await refreshTokenManager.refreshIfNeeded();
+      } catch (error) {
+        console.error('[AxiosHelper] Erro durante o refresh no interceptor de requisição:', error);
+        if (refreshTokenManager.shouldClearTokenOnRefreshError(error)) {
+          refreshTokenManager.clearTokens();
+          window.location.href = process.env.LOGIN_URL ?? '/login';
+          return Promise.reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      }
+
       const token = localStorage.getItem("token");
       if (token) {
         config.headers.Authorization = `Bearer ${token}`;
@@ -66,8 +78,6 @@ export function CreateIntanceAxios() {
         originalRequest._retry = true;
 
         try {
-          const { refreshTokenManager } = await import('../../services/RefreshTokenManager');
-          
           const result = await refreshTokenManager.refreshIfNeeded();
 
           if (result) {
@@ -86,9 +96,6 @@ export function CreateIntanceAxios() {
             }
           }
         } catch (refreshError: any) {
-          // Importação dinâmica do RefreshTokenManager para checar o erro
-          const { refreshTokenManager } = await import('../../services/RefreshTokenManager');
-          
           if (!refreshTokenManager.shouldClearTokenOnRefreshError(refreshError)) {
             // Se for erro de rede ou 5xx durante o refresh, não desloga.
             // Apenas rejeita a requisição atual.


### PR DESCRIPTION
### 📝 Descrição do PR:

#### 🔍 O Problema
Ao entrar na aplicação com um token expirado, múltiplas requisições de API eram disparadas em paralelo. Isso causava dois problemas principais:
1. **Instâncias Duplicadas do Singleton**: O uso de imports dinâmicos (`await import(...)`) em `AxiosHelper.ts` vs imports estáticos em outros arquivos fazia com que o bundler (Vite) instanciasse a classe `RefreshTokenManager` duas vezes em memória. Assim, a Promise de controle de concorrência (`ongoingRefresh`) não era compartilhada, permitindo que vários refreshes fossem chamados ao mesmo tempo.
2. **Atualização Reativa (401)**: A aplicação enviava as requisições com tokens expirados, aguardava o erro `401 Unauthorized` e tentava fazer o refresh de forma reativa. Como o back-end adota rotação de refresh token (invalida o anterior ao gerar um novo), a primeira requisição de refresh funcionava e as demais concorrentes falhavam com 401, deslogando o usuário imediatamente na inicialização do app.

#### 🛠️ O que foi feito
- **Importação Estática**: Substituição de todos os `await import('../../services/RefreshTokenManager')` por um import estático do `refreshTokenManager` no topo de [AxiosHelper.ts](file:///d:/GitHub/FinanMap-Front-End/src/services/api/AxiosHelper.ts), garantindo uma única instância em toda a aplicação.
- **Atualização Proativa no Request Interceptor**: O interceptor de requisição foi tornado assíncrono para verificar proativamente se o token precisa ser atualizado chamando `await refreshTokenManager.refreshIfNeeded()` *antes* de enviar as requisições. 
- **Controle de Fluxo e Erros**: 
  - Se múltiplas requisições forem disparadas ao mesmo tempo, todas aguardarão a mesma Promise do único refresh ativo.
  - Caso ocorra um erro de autenticação definitivo no refresh inicial, a aplicação limpa os tokens do `localStorage` e redireciona o usuário para a tela de login.
  - Correção de erro de tipagem de rejeição no TypeScript, assegurando conformidade com a regra `@typescript-eslint/prefer-promise-reject-errors`.
  - Simplificação do interceptor de resposta para utilizar o `refreshTokenManager` importado estaticamente.