### PR TITLE
Feat/padronizacao modais config

### DIFF
--- a/.specs/dashboard-period-filter/IMPLEMENTATION-PLAN.md
+++ b/.specs/dashboard-period-filter/IMPLEMENTATION-PLAN.md
@@ -1,0 +1,282 @@
+# Implementation Plan — Redesign do Filtro de Período do Dashboard
+
+| Field        | Value                         |
+| ------------ | ----------------------------- |
+| Tech Lead    | @Usuario                      |
+| Team         | Front-end                     |
+| Epic/Ticket  | Dashboard — Filtro de período |
+| Status       | Draft                         |
+| Created      | 2026-06-05                    |
+| Last Updated | 2026-06-05                    |
+
+## Overview
+
+Repensar o filtro de período do dashboard para reduzir a carga visual e tornar os caminhos mais frequentes mais rápidos, sem remover os atalhos existentes nem alterar o contrato atual das consultas.
+
+A proposta usa **divulgação progressiva**:
+
+1. O estado principal mostra o período aplicado e os atalhos `Mês atual`, `Últimos 3 meses` e `Este ano`.
+2. O usuário abre `Personalizar período` somente quando precisa informar um intervalo diferente.
+3. O formulário manual aparece em uma segunda linha, com grupos claros `De` e `Até`, validação inline e ações `Cancelar` e `Aplicar período`.
+
+**Technical Design**: Not provided
+
+**Stack**: Vue 3 + Quasar Framework + Pinia + TypeScript
+
+### Diagnóstico da interface atual
+
+- Os quatro selects, seus rótulos, o separador e o botão `Filtrar` competem visualmente com os atalhos, embora os atalhos representem os caminhos mais rápidos.
+- Os atalhos ficam distantes do título e do intervalo manual; em telas largas, parecem uma ação secundária desconectada.
+- O atalho `Mês atual` desaparece quando ativo, causando mudança de layout e não comunicando qual preset está selecionado.
+- O período aplicado não possui um resumo central e facilmente escaneável; é necessário ler quatro campos.
+- O formulário manual e os atalhos usam padrões diferentes no desktop e mobile, o que aumenta inconsistência.
+- A confirmação positiva por toast após toda aplicação adiciona ruído a uma ação frequente; o resumo do período aplicado pode oferecer feedback persistente.
+- O erro depende de tooltip/toast. A correção deve estar visível junto ao formulário.
+- O CSS usa `transition: all` e as animações da página não tratam `prefers-reduced-motion`.
+
+### Proposta de experiência
+
+**Estado compacto padrão**
+
+```text
+Período do dashboard                         [Personalizar período]
+Junho de 2026
+[Mês atual ✓] [Últimos 3 meses] [Este ano]
+```
+
+**Estado expandido para intervalo personalizado**
+
+```text
+Período do dashboard                         [Fechar]
+Junho de 2026
+[Mês atual] [Últimos 3 meses] [Este ano]
+
+De                 →  Até
+[Mês] [Ano]           [Mês] [Ano]          [Cancelar] [Aplicar período]
+Mensagem de validação inline, quando necessária
+```
+
+### Direção visual
+
+- **Tom**: utilitário refinado, calmo e financeiro; o filtro deve orientar sem disputar atenção com os indicadores.
+- **Hierarquia**: período aplicado em destaque; presets como controle segmentado; edição manual como detalhe secundário.
+- **Estado ativo**: preset selecionado com fundo primário suave, borda e ícone de confirmação. Presets nunca desaparecem.
+- **Feedback**: atalhos aplicam imediatamente; intervalo manual aplica somente pelo botão. O resumo atualizado substitui o toast de sucesso.
+- **Responsividade**: no mobile, atalhos permanecem na primeira camada e podem quebrar em linhas; editor manual ocupa largura total com campos agrupados.
+- **Acessibilidade**: foco visível, rótulos persistentes, erro inline, alvos de toque de pelo menos 44px e suporte a redução de movimento.
+
+## Scope
+
+### Included
+
+- Redesign de `SectionFiltrarPeriodo.vue`.
+- Preservação dos três atalhos existentes e de suas regras de período.
+- Estado visual ativo para preset reconhecido.
+- Resumo do período aplicado usando `Intl.DateTimeFormat('pt-BR')`.
+- Editor manual expansível, validação inline e cancelamento de alterações não aplicadas.
+- Responsividade, dark mode, teclado e redução de movimento.
+- Sincronização opcional do período com query params para preservar o filtro ao recarregar/compartilhar a URL.
+
+### Not Included
+
+- Alterações nos endpoints ou no formato de data enviado ao backend.
+- Novos presets além dos três atuais.
+- Redesign dos cards e gráficos do dashboard.
+- Persistência de preferências no backend.
+
+## Implementation Phases
+
+---
+
+### Phase 1: Tracer Bullet — Filtro compacto com atalhos e edição personalizada
+
+**Goal**: O usuário identifica rapidamente o período aplicado, usa qualquer atalho em um clique e ainda consegue aplicar um intervalo personalizado.
+
+**Vertical slice**: `SectionFiltrarPeriodo.vue` → estado local → `dashboardStore.setFiltros()` → atualização dos cards e gráficos existentes.
+
+**Tasks**:
+
+| ID | Task | Owner | Estimate |
+|----|------|-------|----------|
+| DPF-P1-01 | Reestruturar o template de `SectionFiltrarPeriodo.vue` em cabeçalho, resumo do período, grupo de presets e editor manual expansível. | @Usuario | 2h |
+| DPF-P1-02 | Manter os atalhos `Mês atual`, `Últimos 3 meses` e `Este ano` sempre visíveis; aplicar imediatamente e indicar visualmente o preset correspondente ao período aplicado. | @Usuario | 1h |
+| DPF-P1-03 | Criar resumo computado do período aplicado: `Junho de 2026` para mês único e `Abril a Junho de 2026` ou `Dezembro de 2025 a Fevereiro de 2026` para intervalos. Usar `Intl.DateTimeFormat('pt-BR')`. | @Usuario | 1h |
+| DPF-P1-04 | Implementar `Personalizar período`, `Cancelar` e `Aplicar período`; `Cancelar` restaura o rascunho com os valores atualmente aplicados. | @Usuario | 1h |
+| DPF-P1-05 | Substituir tooltip/toast de erro por mensagem inline; desabilitar `Aplicar período` enquanto o intervalo for inválido e manter o formulário aberto. | @Usuario | 45min |
+| DPF-P1-06 | Remover o toast positivo da aplicação bem-sucedida; usar a mudança do resumo e do estado ativo como confirmação persistente. | @Usuario | 15min |
+
+**Testing**:
+
+- Manual: aplicar cada preset e confirmar atualização de todos os cards/gráficos.
+- Manual: abrir editor, alterar campos, cancelar e confirmar restauração do período aplicado.
+- Manual: tentar aplicar início posterior ao fim e confirmar erro inline sem chamada à store.
+- Regressão: confirmar que `dashboardStore.setFiltros()` continua recebendo mês/ano inicial e final no mesmo formato.
+
+**Acceptance Criteria**:
+
+- [ ] Os três atalhos permanecem sempre visíveis e aplicam o período em um clique.
+- [ ] O preset correspondente ao período aplicado possui estado ativo perceptível.
+- [ ] O período aplicado é legível sem abrir o editor manual.
+- [ ] O editor manual inicia fechado e pode ser aberto pelo botão `Personalizar período`.
+- [ ] `Cancelar` descarta alterações locais e mantém o dashboard inalterado.
+- [ ] Intervalo inválido exibe mensagem inline e não pode ser aplicado.
+- [ ] Cards e gráficos continuam atualizando pelo contrato atual da store.
+
+**Dependencies**: Nenhuma dependência externa; utiliza componentes Quasar e a store existentes.
+
+---
+
+### Phase 2: Responsividade, acessibilidade e refinamento visual
+
+**Goal**: O novo filtro funciona com clareza em desktop, tablet, mobile, dark mode e navegação por teclado.
+
+**Vertical slice**: marcação semântica → componentes Quasar → estilos responsivos → interação por teclado e leitores de tela.
+
+**Tasks**:
+
+| ID | Task | Owner | Estimate |
+|----|------|-------|----------|
+| DPF-P2-01 | Criar layout responsivo: cabeçalho e atalhos compactos no desktop; controles empilhados e ações em largura total no mobile; evitar overflow horizontal em 320px. | @Usuario | 1.5h |
+| DPF-P2-02 | Refinar estados light/dark, ativo, hover, pressed, disabled e `focus-visible`, mantendo contraste suficiente e alvos de toque de pelo menos 44px. | @Usuario | 1.5h |
+| DPF-P2-03 | Garantir nomes acessíveis e rótulos persistentes para controles; ligar mensagem de erro ao editor com `aria-live="polite"`/equivalente Quasar. | @Usuario | 1h |
+| DPF-P2-04 | Trocar `transition: all` por propriedades específicas e adicionar tratamento de `prefers-reduced-motion` ao filtro e às animações de entrada do dashboard. | @Usuario | 45min |
+| DPF-P2-05 | Validar conteúdo e truncamento com nomes de meses longos, zoom de 200% e diferentes larguras. | @Usuario | 45min |
+
+**Testing**:
+
+- Browser: testar em 320px, 480px, 768px, 1024px e 1440px.
+- Acessibilidade manual: navegar somente por teclado, verificar ordem de foco e foco visível.
+- Temas: validar light e dark mode.
+- Preferências: ativar `prefers-reduced-motion` e confirmar remoção/redução das animações.
+
+**Acceptance Criteria**:
+
+- [ ] Nenhum controle ou texto é cortado em 320px ou com zoom de 200%.
+- [ ] Todos os controles podem ser usados somente por teclado.
+- [ ] Foco, preset ativo, erro e estado desabilitado são distinguíveis em light e dark mode.
+- [ ] Mensagem de erro fica visível junto aos campos e é anunciada de forma acessível.
+- [ ] Animações respeitam `prefers-reduced-motion`.
+
+**Dependencies**: Phase 1 completa.
+
+---
+
+### Phase 3: Persistência do período e produção
+
+**Goal**: O filtro mantém contexto após recarregar a página e pode ser liberado com baixo risco.
+
+**Vertical slice**: rota do dashboard → query params → inicialização da store → filtro → consultas existentes.
+
+**Tasks**:
+
+| ID | Task | Owner | Estimate |
+|----|------|-------|----------|
+| DPF-P3-01 | Sincronizar período aplicado com query params (`inicio=YYYY-MM` e `fim=YYYY-MM`) usando Vue Router, sem registrar alterações ainda não aplicadas. | @Usuario | 1.5h |
+| DPF-P3-02 | Na entrada da página, validar query params e inicializar a store; ignorar valores inválidos com fallback para o mês atual. | @Usuario | 1h |
+| DPF-P3-03 | Executar regressão completa do dashboard, incluindo recarga, back/forward, URL compartilhada, modo compartilhado, light/dark e falhas de API. | @Usuario | 1.5h |
+| DPF-P3-04 | Documentar evidências visuais antes/depois e checklist de release no ticket da entrega. | @Usuario | 30min |
+
+**Testing**:
+
+- Recarregar uma URL com período customizado e confirmar restauração do mesmo intervalo.
+- Navegar com back/forward após trocar períodos e confirmar estado consistente.
+- Abrir URL com query inválida e confirmar fallback sem quebrar o dashboard.
+- Executar `npm run lint` e `npm run build`.
+
+**Acceptance Criteria**:
+
+- [ ] Recarregar a página preserva o período aplicado.
+- [ ] Query params inválidos não causam erro nem intervalo inválido.
+- [ ] Trocas de período não geram loops de navegação ou consultas duplicadas indevidas.
+- [ ] `npm run lint` e `npm run build` concluem sem novos erros.
+
+**Dependencies**: Phase 2 completa; alinhamento de produto para incluir query params no escopo final.
+
+## Milestones
+
+| Milestone | Target Date | Description |
+|-----------|-------------|-------------|
+| Experiência principal validável | 2026-06-08 | Filtro compacto, presets ativos e editor manual funcional |
+| Refinamento responsivo e acessível | 2026-06-10 | Interface validada em breakpoints, temas e teclado |
+| Pronto para produção | 2026-06-12 | Persistência por URL, regressão e build validados |
+
+As datas são propostas e podem ser ajustadas conforme a prioridade da equipe.
+
+## Dependencies
+
+| Dependency | Type | Owner | Status | Risk if Delayed |
+|------------|------|-------|--------|-----------------|
+| `dashboardStore.setFiltros()` | Internal | @Usuario | Disponível | Alteração de contrato pode afetar todos os gráficos |
+| Componentes `InputSelectMes` e `InputSelectAno` | Internal | @Usuario | Disponível | Limitações de acessibilidade/estilo podem exigir pequenos ajustes compartilhados |
+| Vue Router | Internal | @Usuario | Disponível | Necessário apenas para persistência por URL na Phase 3 |
+| Validação visual em Browser | Technical | @Usuario | Pendente | Problemas responsivos podem chegar à produção sem inspeção real |
+
+## Risks
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| Usuário não percebe que o período personalizado está disponível por estar recolhido | Médio | Baixa | Usar botão explícito `Personalizar período`, ícone de calendário e teste visual em desktop/mobile |
+| Estado local diverge do período aplicado após ações externas | Alto | Média | Manter watchers da store e separar claramente `draftPeriod` de `appliedPeriod` |
+| Preset ativo é identificado incorretamente em virada de mês/ano | Médio | Média | Centralizar cálculo dos presets em funções puras e testar dezembro/janeiro |
+| Query params criam consultas duplicadas ou loop de rota | Alto | Baixa | Atualizar URL apenas após aplicação e comparar valores antes de chamar `router.replace` |
+| Mudança em inputs compartilhados afeta outras telas | Alto | Baixa | Priorizar props/classes locais; alterar componentes compartilhados somente com regressão das telas consumidoras |
+
+## Testing Strategy
+
+O projeto não possui suíte automatizada configurada (`npm test` apenas informa que não há testes). A entrega deve combinar verificações estáticas, build e testes manuais focados.
+
+### Static and Build
+
+- `npm run lint`
+- `npm run build`
+
+### Functional Scenarios
+
+1. Carregamento inicial no mês atual.
+2. Aplicação de cada preset.
+3. Aplicação de intervalo personalizado no mesmo ano.
+4. Aplicação de intervalo personalizado atravessando anos.
+5. Cancelamento de rascunho.
+6. Tentativa de intervalo inválido.
+7. Mudança de preset após editar sem aplicar.
+8. Recarga e navegação back/forward com query params.
+
+### Visual and Accessibility
+
+- Breakpoints: 320px, 480px, 768px, 1024px e 1440px.
+- Light mode e dark mode.
+- Zoom de 200%.
+- Navegação somente por teclado.
+- `prefers-reduced-motion`.
+
+## Rollback Plan
+
+### Deployment Strategy
+
+Entregar em commits separados por fase. Se houver ambiente de homologação, validar Phase 1 e Phase 2 antes de habilitar a persistência por URL da Phase 3.
+
+### Rollback Triggers
+
+- Presets aplicam períodos incorretos.
+- Cards ou gráficos deixam de atualizar.
+- Filtro fica inutilizável em mobile.
+- Query params causam loop, consultas repetidas ou quebra no carregamento.
+
+### Rollback Steps
+
+1. Reverter primeiro a sincronização por query params, preservando o redesign visual.
+2. Se o problema estiver no fluxo principal, restaurar a versão anterior de `SectionFiltrarPeriodo.vue`.
+3. Validar o dashboard no mês atual e com intervalo manual após o rollback.
+
+## Validation Checklist
+
+- [x] Technical design referenced: não fornecido
+- [x] Phase 1 entrega valor visível ponta a ponta
+- [x] Todas as fases possuem goal, vertical slice, tasks, testing, acceptance criteria e dependencies
+- [x] IDs seguem o padrão `DPF-PN-NN`
+- [x] Testes estão incorporados em cada fase
+- [x] Nenhuma fase é apenas setup
+- [x] Milestones e datas propostas definidos
+- [x] Dependencies e riscos documentados
+- [x] Testing Strategy incluída
+- [x] Rollback Plan incluído

--- a/.specs/dashboard-period-filter/IMPLEMENTATION-STATE.md
+++ b/.specs/dashboard-period-filter/IMPLEMENTATION-STATE.md
@@ -1,0 +1,26 @@
+# Implementation State: dashboard-period-filter
+
+## Phase 1 -- Tracer Bullet: Filtro compacto com atalhos e edição personalizada
+- [x] DPF-P1-01: Reestruturar o template em cabeçalho, resumo, presets e editor manual expansível.
+- [x] DPF-P1-02: Manter os três atalhos visíveis, aplicar imediatamente e indicar o preset ativo.
+- [x] DPF-P1-03: Criar resumo computado do período aplicado com `Intl.DateTimeFormat('pt-BR')`.
+- [x] DPF-P1-04: Implementar personalização, cancelamento e aplicação do período.
+- [x] DPF-P1-05: Exibir validação inline e impedir aplicação de intervalo inválido.
+- [x] DPF-P1-06: Remover toast positivo da aplicação bem-sucedida.
+
+**Status: completed**
+
+**Validation:** `npm run lint` e `npm run build` concluídos com sucesso. A aplicação local inicia normalmente, mas a validação visual autenticada do dashboard ficou indisponível sem credenciais.
+
+## Phase 2 -- Responsividade, acessibilidade e refinamento visual
+- [ ] DPF-P2-01: Criar layout responsivo sem overflow horizontal.
+- [ ] DPF-P2-02: Refinar estados visuais, contraste, foco e alvos de toque.
+- [ ] DPF-P2-03: Garantir nomes acessíveis, rótulos persistentes e anúncio do erro.
+- [ ] DPF-P2-04: Restringir transições e respeitar redução de movimento.
+- [ ] DPF-P2-05: Validar meses longos, zoom e diferentes larguras.
+
+## Phase 3 -- Persistência do período e produção
+- [ ] DPF-P3-01: Sincronizar período aplicado com query params.
+- [ ] DPF-P3-02: Validar query params e inicializar a store.
+- [ ] DPF-P3-03: Executar regressão completa do dashboard.
+- [ ] DPF-P3-04: Documentar evidências e checklist de release.

--- a/.specs/dashboard-period-filter/IMPLEMENTATION-STATE.md
+++ b/.specs/dashboard-period-filter/IMPLEMENTATION-STATE.md
@@ -1,6 +1,7 @@
 # Implementation State: dashboard-period-filter
 
 ## Phase 1 -- Tracer Bullet: Filtro compacto com atalhos e edição personalizada
+
 - [x] DPF-P1-01: Reestruturar o template em cabeçalho, resumo, presets e editor manual expansível.
 - [x] DPF-P1-02: Manter os três atalhos visíveis, aplicar imediatamente e indicar o preset ativo.
 - [x] DPF-P1-03: Criar resumo computado do período aplicado com `Intl.DateTimeFormat('pt-BR')`.
@@ -13,6 +14,7 @@
 **Validation:** `npm run lint` e `npm run build` concluídos com sucesso. A aplicação local inicia normalmente, mas a validação visual autenticada do dashboard ficou indisponível sem credenciais.
 
 ## Phase 2 -- Responsividade, acessibilidade e refinamento visual
+
 - [x] DPF-P2-01: Criar layout responsivo sem overflow horizontal.
 - [x] DPF-P2-02: Refinar estados visuais, contraste, foco e alvos de toque.
 - [x] DPF-P2-03: Garantir nomes acessíveis, rótulos persistentes e anúncio do erro.
@@ -27,7 +29,15 @@ larguras, alvos de 44px, nomes acessíveis e redução de movimento. A inspeçã
 do dashboard continua indisponível sem credenciais.
 
 ## Phase 3 -- Persistência do período e produção
-- [ ] DPF-P3-01: Sincronizar período aplicado com query params.
-- [ ] DPF-P3-02: Validar query params e inicializar a store.
-- [ ] DPF-P3-03: Executar regressão completa do dashboard.
-- [ ] DPF-P3-04: Documentar evidências e checklist de release.
+
+- [x] DPF-P3-01: Sincronizar período aplicado com query params.
+- [x] DPF-P3-02: Validar query params e inicializar a store.
+- [x] DPF-P3-03: Executar regressão completa do dashboard.
+- [x] DPF-P3-04: Documentar evidências e checklist de release.
+
+**Status: completed**
+
+**Validation:** regras puras de query exercitadas em 6 cenários; `npm test`, `npm run lint` e
+`npm run build` concluídos com sucesso. O navegador local confirmou a guarda de autenticação,
+mas a regressão visual completa do dashboard autenticado permaneceu indisponível sem
+credenciais. Evidências e pendências estão em `RELEASE-CHECKLIST.md`.

--- a/.specs/dashboard-period-filter/IMPLEMENTATION-STATE.md
+++ b/.specs/dashboard-period-filter/IMPLEMENTATION-STATE.md
@@ -13,11 +13,18 @@
 **Validation:** `npm run lint` e `npm run build` concluídos com sucesso. A aplicação local inicia normalmente, mas a validação visual autenticada do dashboard ficou indisponível sem credenciais.
 
 ## Phase 2 -- Responsividade, acessibilidade e refinamento visual
-- [ ] DPF-P2-01: Criar layout responsivo sem overflow horizontal.
-- [ ] DPF-P2-02: Refinar estados visuais, contraste, foco e alvos de toque.
-- [ ] DPF-P2-03: Garantir nomes acessíveis, rótulos persistentes e anúncio do erro.
-- [ ] DPF-P2-04: Restringir transições e respeitar redução de movimento.
-- [ ] DPF-P2-05: Validar meses longos, zoom e diferentes larguras.
+- [x] DPF-P2-01: Criar layout responsivo sem overflow horizontal.
+- [x] DPF-P2-02: Refinar estados visuais, contraste, foco e alvos de toque.
+- [x] DPF-P2-03: Garantir nomes acessíveis, rótulos persistentes e anúncio do erro.
+- [x] DPF-P2-04: Restringir transições e respeitar redução de movimento.
+- [x] DPF-P2-05: Validar meses longos, zoom e diferentes larguras.
+
+**Status: completed**
+
+**Validation:** `npm test`, `npm run lint` e `npm run build` concluídos com sucesso. A revisão
+estática confirmou quebra em coluna única abaixo de 380px, controles flexíveis nas demais
+larguras, alvos de 44px, nomes acessíveis e redução de movimento. A inspeção visual autenticada
+do dashboard continua indisponível sem credenciais.
 
 ## Phase 3 -- Persistência do período e produção
 - [ ] DPF-P3-01: Sincronizar período aplicado com query params.

--- a/.specs/dashboard-period-filter/RELEASE-CHECKLIST.md
+++ b/.specs/dashboard-period-filter/RELEASE-CHECKLIST.md
@@ -1,0 +1,30 @@
+# Dashboard Period Filter — Release Checklist
+
+## Evidências da Phase 3
+
+- A rota do dashboard usa `inicio=YYYY-MM` e `fim=YYYY-MM`.
+- Uma URL válida inicializa a store antes da montagem dos componentes filhos.
+- Query ausente, repetida, malformada, com mês inválido ou intervalo invertido retorna ao mês atual.
+- Alterações aplicadas na store atualizam a URL com `router.replace`.
+- Comparações antes de `setFiltros` e `router.replace` evitam consultas e navegações duplicadas.
+- Os demais query params da rota são preservados.
+
+## Regressão
+
+- [x] Regras puras de query: 6 cenários exercitados com sucesso.
+- [x] Contrato de `dashboardStore.setFiltros(mesInicial, anoInicial, mesFinal, anoFinal)` preservado.
+- [x] Watchers dos cards e gráficos continuam reagindo a `dataInicial` e `dataFinal`.
+- [x] `npm test` executado; o projeto informa que não possui testes automatizados configurados.
+- [x] `npm run lint` concluído sem erros.
+- [x] `npm run build` concluído sem erros.
+- [x] Guarda de autenticação confirmada no navegador local.
+- [ ] Dashboard autenticado, recarga, back/forward, modos compartilhado/light/dark e falhas de API:
+      validação visual indisponível sem credenciais.
+
+## Checklist de release
+
+- [x] Formato de query documentado.
+- [x] Fallback para query inválida implementado.
+- [x] Proteções contra loop e duplicidade implementadas.
+- [x] Build de produção gerado.
+- [ ] Executar smoke test autenticado em homologação antes da liberação.

--- a/.specs/padronizacao-modais-config/IMPLEMENTATION-PLAN.md
+++ b/.specs/padronizacao-modais-config/IMPLEMENTATION-PLAN.md
@@ -1,0 +1,165 @@
+# Implementation Plan — Padronização Visual das Modais de Configuração
+
+| Field        | Value                        |
+| ------------ | ---------------------------- |
+| Tech Lead    | @Antigravity                 |
+| Team         | Matheus                      |
+| Epic/Ticket  | Padronização de Layout Modais |
+| Status       | In Review                    |
+| Created      | 2026-06-05                   |
+| Last Updated | 2026-06-05                   |
+
+## Overview
+
+Este plano de implementação visa padronizar visualmente as três telas integradas à modal de configurações (`ModalConfiguracoes.vue`):
+1. **Informações da Conta** (`InformacoesConta.vue`)
+2. **Categorias** (`CategoriaConfig.vue`)
+3. **Compartilhamento de Dados** (`CompartilhamentoConfig.vue`)
+
+Atualmente, essas três modais possuem identidades visuais distintas causadas por terem sido desenvolvidas em épocas diferentes. A padronização focará em unificar a estrutura usando um cabeçalho padronizado (Avatar + Título + Subtítulo/Descrição) e organizando os controles/formulários dentro de cartões flat (`q-card`) com bordas arredondadas de `16px` (`rounded-borders-xl`), sombras discretas, alinhamento responsivo para dispositivos móveis e suporte completo ao Dark Mode.
+
+**Technical Design**: Not provided
+
+## Implementation Phases
+
+### Phase 1: Padronização de "Informações da Conta" (Tracer Bullet)
+
+**Goal**: Padronizar a tela de conta como prova de conceito, aplicando o cabeçalho unificado e os cards de configuração.
+
+**Vertical slice**: Camada de UI do componente `InformacoesConta.vue`.
+
+**Tasks**:
+
+| ID | Task | Owner | Estimate |
+|----|------|-------|----------|
+| [CFG-P1-01] | Refatorar cabeçalho: integrar o avatar do usuário com o nome e e-mail no formato unificado (avatar de 48px + título + legenda). | @Antigravity | 2h |
+| [CFG-P1-02] | Envelopar a seção de "Aparência" (tema claro/escuro) em um `q-card` flat e bordered usando a classe `.rounded-borders-xl`. | @Antigravity | 2h |
+| [CFG-P1-03] | Envelopar a seção de "Notificações" (lembretes de e-mail) em um card idêntico, ajustando o banner de modo compartilhado. | @Antigravity | 2h |
+| [CFG-P1-04] | Validar a reatividade do tema, consistência visual em Dark Mode e responsividade no mobile. | @Antigravity | 1h |
+
+**Testing**:
+- **Teste Visual**: Validar renderização do avatar e alinhamentos de texto no desktop e mobile.
+- **Teste de Estado**: Mudar o tema para escuro e claro e confirmar se as cores dos cards e textos se adaptam conforme definido no `app.scss`.
+- **Teste Funcional**: Clicar nos botões de tema e toggle de notificação para garantir que as ações continuam gravando no store/serviço.
+
+**Acceptance Criteria**:
+- [ ] O cabeçalho possui um avatar de `48px` com a letra inicial do usuário à esquerda, o nome destacado à direita e o e-mail em uma linha abaixo com cor suavizada.
+- [ ] As seções "Aparência" e "Notificações" estão envelopadas em cartões com bordas de `16px`, borda sutil e sombra suave.
+- [ ] O layout é responsivo (se adapta perfeitamente ao mobile).
+
+**Dependencies**: Nenhuma.
+
+---
+
+### Phase 2: Padronização de "Categorias"
+
+**Goal**: Adaptar a tela de categorias para o novo layout unificado, inserindo o cabeçalho e agrupando a tabela/filtros em um card.
+
+**Vertical slice**: Camada de UI do componente `CategoriaConfig.vue`.
+
+**Tasks**:
+
+| ID | Task | Owner | Estimate |
+|----|------|-------|----------|
+| [CFG-P2-01] | Substituir o parágrafo de descrição simples pelo cabeçalho padronizado (Avatar 48px com ícone `category` + título + legenda). | @Antigravity | 2h |
+| [CFG-P2-02] | Envelopar o controle de filtros (`q-tabs`, `q-input` de busca, botão Criar) e a tabela de dados (`q-table`) em um `q-card` flat bordered padronizado. | @Antigravity | 2h |
+| [CFG-P2-03] | Ajustar paddings e margens internas para que o conteúdo do card não fique muito apertado nem com espaços excessivos. | @Antigravity | 1h |
+| [CFG-P2-04] | Testar o fluxo de listagem, troca de abas de tipo de categoria, edição in-line e exclusão. | @Antigravity | 1h |
+
+**Testing**:
+- **Teste Visual**: Confirmar se o cabeçalho e o card da tabela combinam visualmente com o componente de Informações da Conta criado na Fase 1.
+- **Teste de Fluxo**: Criar, editar e deletar uma categoria para garantir que as modais nativas de diálogo do Quasar funcionam perfeitamente sobre o novo layout de card.
+
+**Acceptance Criteria**:
+- [ ] A descrição simples foi removida e substituída pelo cabeçalho com avatar azul de `48px` (ícone `category`).
+- [ ] A toolbar e a tabela estão consolidadas visualmente dentro de um cartão flat com borda arredondada de `16px`.
+- [ ] O layout da tabela e do filtro é totalmente responsivo no mobile.
+
+**Dependencies**: Phase 1 concluída e aprovada.
+
+---
+
+### Phase 3: Refinamento de "Compartilhamento de Dados"
+
+**Goal**: Refinar a tela de compartilhamento de dados para garantir que se alinhe perfeitamente aos padrões das fases anteriores.
+
+**Vertical slice**: Camada de UI do componente `CompartilhamentoConfig.vue`.
+
+**Tasks**:
+
+| ID | Task | Owner | Estimate |
+|----|------|-------|----------|
+| [CFG-P3-01] | Ajustar o cabeçalho existente para usar o tamanho padrão de avatar (`48px`) e harmonizar os estilos tipográficos. | @Antigravity | 1h |
+| [CFG-P3-02] | Uniformizar as classes dos cards ("Convidar", "Pessoas com Acesso", "Acessos Liberados", "Convites") para usarem exatamente as mesmas propriedades físicas e de sombra dos componentes anteriores. | @Antigravity | 2h |
+| [CFG-P3-03] | Validar fluxos de convites e permissões sobre o layout revisado. | @Antigravity | 1h |
+
+**Testing**:
+- **Teste Visual**: Garantir coerência tipográfica e de sombras com as modais de Conta e Categoria.
+- **Teste Funcional**: Simular envio e resposta a convites para garantir que os componentes e badges de status atualizam corretamente.
+
+**Acceptance Criteria**:
+- [ ] O cabeçalho possui avatar de `48px` e tipografia idêntica às telas de Conta e Categoria.
+- [ ] Todos os cards do fluxo de compartilhamento usam a classe `rounded-borders-xl` e `shadow-1` com paddings idênticos.
+
+**Dependencies**: Phase 2 concluída.
+
+---
+
+### Phase 4: Ajustes de Integração e Mobile no Modal Principal
+
+**Goal**: Garantir que o container principal do modal renderize perfeitamente as 3 telas sem margens duplicadas ou problemas de rolagem.
+
+**Vertical slice**: Layout global do modal (`ModalConfiguracoes.vue`).
+
+**Tasks**:
+
+| ID | Task | Owner | Estimate |
+|----|------|-------|----------|
+| [CFG-P4-01] | Revisar espaçamentos do container e remover margens excessivas ao redor das telas filhas. | @Antigravity | 2h |
+| [CFG-P4-02] | Otimizar visualização mobile (garantir que a barra lateral de navegação oculte/exiba corretamente e que as telas caibam na tela). | @Antigravity | 2h |
+| [CFG-P4-03] | Realizar validação final e correção de pequenos bugs de alinhamento em todos os navegadores/resoluções. | @Antigravity | 1h |
+
+**Testing**:
+- **Teste de Navegação**: Alternar rapidamente entre as 3 abas e observar se ocorrem saltos visuais indesejados ou quebras de layout.
+- **Teste Responsivo**: Simular visualização em telas de `320px`, `375px`, `768px` e `1024px+` usando ferramentas de desenvolvedor.
+
+**Acceptance Criteria**:
+- [ ] O modal de configurações se comporta de forma totalmente fluida ao alternar entre as 3 abas.
+- [ ] Não há barras de rolagem horizontais ou sobreposição de texto em resoluções mobile.
+
+**Dependencies**: Faves 1, 2 e 3 concluídas.
+
+## Milestones
+
+| Milestone | Target Date | Description |
+|-----------|-------------|-------------|
+| M1: Prova de Conceito (Conta) | 2026-06-08 | Tela de Informações da Conta padronizada com o novo cabeçalho e cards de preferências. |
+| M2: Categorias Unificadas | 2026-06-10 | Tela de Categorias migrada para o estilo de cartões e cabeçalho consistente. |
+| M3: Design Coeso Completo | 2026-06-12 | Todas as 3 telas e o modal principal funcionando de forma integrada, responsiva e com suporte total a Dark Mode. |
+
+## Dependencies
+
+| Dependency | Type | Owner | Status | Risk if Delayed |
+|------------|------|-------|--------|-----------------|
+| Nenhuma | N/A | @Antigravity | Concluído | Nenhum |
+
+## Risks
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| Quebra de layouts responsivos devido a tamanhos fixos de componentes antigos | M | M | Utilizar classes flexíveis do Quasar (`row`, `col`, `col-12`, `col-md-*`) e evitar `width` fixo nos cards. |
+| Divergência na paleta de cores entre o modo claro e escuro | M | L | Utilizar as variáveis globais de CSS do `app.scss` (como `--bg-card`, `--text-primary`) e cores semânticas do Quasar. |
+| Conflitos de padding em navegadores móveis antigos | L | L | Testar extensivamente emulando múltiplos aparelhos nos DevTools e usando classes utilitárias padrões do Quasar. |
+
+## Testing Strategy
+1. **Testes de Regressão Visual**:
+   - Comparação das telas antes e depois para garantir que nenhum elemento funcional (como o botão de exclusão de categoria ou toggle de convite) tenha sumido ou ficado inacessível.
+2. **Testes de Responsividade**:
+   - Testar o comportamento das telas em breakpoints do Quasar: `xs` (mobile), `sm` (tablet) e `md+` (desktop).
+3. **Testes de Modo Escuro**:
+   - Garantir legibilidade perfeita dos textos em fundo escuro em todos os novos componentes de card.
+
+## Rollback Plan
+- Falha catastrófica de renderização que impeça o usuário de salvar configurações críticas.
+- Problemas de usabilidade severos no mobile que impeçam o fechamento do modal ou a navegação.
+- **Passos**: Fazer rollback imediato dos commits de UI usando Git para a versão estável anterior.

--- a/src/components/Compartilhamento/CompartilhamentoConfig.vue
+++ b/src/components/Compartilhamento/CompartilhamentoConfig.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="compartilhamento-config q-pa-sm">
+  <div class="compartilhamento-config q-pa-none">
     <!-- Cabeçalho -->
-    <div class="q-mb-lg flex items-center q-gutter-x-sm">
+    <div class="q-mb-md flex items-center q-gutter-x-sm">
       <q-avatar color="primary" text-color="white" icon="share" font-size="24px" size="48px" />
       <div>
         <div class="text-h5 text-weight-bold">Compartilhamento de Dados</div>
@@ -381,6 +381,14 @@ function confirmarRevogacao(compartilhamentoId: string) {
 
 .rounded-borders-xl {
   border-radius: 16px;
+}
+
+.shadow-1 {
+  transition: box-shadow 0.3s ease;
+}
+
+.shadow-1:hover {
+  box-shadow: 0 6px 20px v-bind('$q.dark.isActive ? "rgba(0,0,0,0.4)" : "rgba(0,0,0,0.08)"') !important;
 }
 
 .opacity-50 {

--- a/src/components/Compartilhamento/CompartilhamentoConfig.vue
+++ b/src/components/Compartilhamento/CompartilhamentoConfig.vue
@@ -58,9 +58,14 @@
         <!-- Meus Compartilhamentos -->
         <q-card flat bordered class="rounded-borders-xl shadow-1 full-height">
           <q-card-section>
-            <div class="text-subtitle1 text-weight-bold flex items-center q-gutter-x-sm q-mb-md">
+            <div class="flex items-start q-gutter-x-sm q-mb-md">
               <q-icon name="manage_accounts" size="sm" color="primary" />
-              <span>Pessoas com Acesso</span>
+              <div>
+                <div class="text-subtitle1 text-weight-bold">Contas com acesso aos meus dados</div>
+                <div class="text-caption text-grey-7">
+                  Gerencie as pessoas convidadas para visualizar ou editar seus dados.
+                </div>
+              </div>
             </div>
 
             <q-list separator v-if="compartilhamentoStore.meusCompartilhamentos.length > 0">
@@ -110,9 +115,14 @@
       <div class="col-12">
         <q-card flat bordered class="rounded-borders-xl shadow-1 full-height">
           <q-card-section>
-            <div class="text-subtitle1 text-weight-bold flex items-center q-gutter-x-sm q-mb-md">
+            <div class="flex items-start q-gutter-x-sm q-mb-md">
               <q-icon name="folder_shared" size="sm" color="primary" />
-              <span>Acessos Liberados Para Mim</span>
+              <div>
+                <div class="text-subtitle1 text-weight-bold">Dados compartilhados comigo</div>
+                <div class="text-caption text-grey-7">
+                  Acesse os dados que outras pessoas compartilharam com você.
+                </div>
+              </div>
             </div>
 
             <q-list separator v-if="compartilhamentoStore.compartilhamentosAceitos.length > 0">

--- a/src/components/Compartilhamento/CompartilhamentoModal.vue
+++ b/src/components/Compartilhamento/CompartilhamentoModal.vue
@@ -1,175 +1,229 @@
 <template>
-  <q-dialog v-model="showDialog" @hide="onHide">
-    <q-card style="min-width: 500px; max-width: 600px" :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'">
-      <q-card-section class="row items-center q-pb-sm">
-        <div class="text-h6">Compartilhar "{{ tituloContexto }}"</div>
+  <q-dialog v-model="showDialog" @hide="onHide" backdrop-filter="brightness(60%)">
+    <q-card
+      class="compartilhamento-modal column no-wrap"
+      :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
+    >
+      <q-card-section class="row no-wrap items-start q-pa-lg q-pb-md">
+        <q-avatar color="primary" text-color="white" icon="share" size="48px" class="q-mr-md" />
+        <div class="col">
+          <div class="text-h6 text-weight-bold">Compartilhar {{ tituloContexto }}</div>
+          <div class="text-caption text-grey-7 q-mt-xs">
+            Convide pessoas e defina como elas podem acessar seus dados financeiros.
+          </div>
+        </div>
         <q-space />
-        <q-btn icon="close" flat round dense v-close-popup />
+        <q-btn icon="close" flat round dense color="grey-7" v-close-popup>
+          <q-tooltip>Fechar</q-tooltip>
+        </q-btn>
       </q-card-section>
 
       <q-separator />
 
-      <q-card-section class="q-pt-md">
-        <div class="row q-col-gutter-sm">
-          <div class="col-12 col-sm-8">
-            <q-input
-              v-model="novoEmail"
-              outlined
-              dense
-              placeholder="Adicionar participantes, grupos, espaços e eventos da agenda"
-              :dark="$q.dark.isActive"
-              @keyup.enter="enviarConvite"
-            >
-              <template v-slot:prepend>
-                <q-icon name="person_add" />
-              </template>
-            </q-input>
-          </div>
-          <div class="col-12 col-sm-4">
-            <q-select
-              v-model="novaPermissao"
-              :options="opcoesPermissao"
-              outlined
-              dense
-              emit-value
-              map-options
-              :dark="$q.dark.isActive"
-            />
-          </div>
-        </div>
-        <div class="row q-mt-sm">
-          <q-btn
-            color="primary"
-            label="Enviar Convite"
-            icon="send"
-            :loading="loadingConvite"
-            :disable="!novoEmail"
-            @click="enviarConvite"
-            unelevated
-          />
-        </div>
-      </q-card-section>
-
-      <q-separator />
-
-      <q-card-section>
-        <div class="text-subtitle2 q-mb-sm text-weight-medium">Pessoas com acesso (convites enviados)</div>
-        
-        <q-item class="q-px-none">
-          <q-item-section avatar>
-            <q-avatar color="primary" text-color="white">
-              <q-icon name="person" />
-            </q-avatar>
-          </q-item-section>
-          <q-item-section>
-            <q-item-label>{{ nomeUsuario }} (you)</q-item-label>
-            <q-item-label caption>{{ emailUsuario }}</q-item-label>
-          </q-item-section>
-          <q-item-section side>
-            <q-item-label class="text-grey">Proprietário</q-item-label>
-          </q-item-section>
-        </q-item>
-
-        <q-item
-          v-for="comp in compartilhamentosAtivos"
-          :key="comp.id"
-          class="q-px-none"
+      <q-card-section class="col scroll q-pa-lg">
+        <div
+          class="convite-panel q-pa-md q-mb-lg"
+          :class="$q.dark.isActive ? 'convite-panel--dark' : 'convite-panel--light'"
         >
-          <q-item-section avatar>
-            <q-avatar color="blue-4" text-color="white">
-              <q-icon name="person" />
-            </q-avatar>
-          </q-item-section>
-          <q-item-section>
-            <q-item-label>{{ comp.convidadoEmail }}</q-item-label>
-            <q-item-label caption>{{ statusTexto(comp.status) }}</q-item-label>
-          </q-item-section>
-          <q-item-section side>
-            <div class="row items-center q-gutter-sm">
+          <div class="row items-center q-mb-md">
+            <q-icon name="person_add" color="primary" size="22px" class="q-mr-sm" />
+            <div>
+              <div class="text-subtitle1 text-weight-bold">Convidar uma pessoa</div>
+              <div class="text-caption text-grey-7">
+                O convite será enviado para o e-mail informado.
+              </div>
+            </div>
+          </div>
+
+          <div class="row q-col-gutter-sm items-start">
+            <div class="col-12 col-sm">
+              <q-input
+                v-model="novoEmail"
+                type="email"
+                outlined
+                dense
+                label="E-mail"
+                placeholder="nome@exemplo.com"
+                hide-bottom-space
+                :dark="$q.dark.isActive"
+                @keyup.enter="enviarConvite"
+              >
+                <template v-slot:prepend>
+                  <q-icon name="mail_outline" />
+                </template>
+              </q-input>
+            </div>
+            <div class="col-12 col-sm-auto permissao-convite">
               <q-select
-                v-if="comp.status === StatusConvite.Aceito"
-                :model-value="comp.permissao"
+                v-model="novaPermissao"
                 :options="opcoesPermissao"
                 outlined
                 dense
+                label="Permissão"
+                hide-bottom-space
                 emit-value
                 map-options
-                style="min-width: 120px"
                 :dark="$q.dark.isActive"
-                @update:model-value="(val) => atualizarPermissao(comp.id, val)"
-              />
-              <q-btn
-                flat
-                dense
-                round
-                icon="delete"
-                color="grey"
-                @click="confirmarRevogacao(comp.id)"
               >
-                <q-tooltip>Remover acesso</q-tooltip>
-              </q-btn>
+                <template v-slot:prepend>
+                  <q-icon name="vpn_key" />
+                </template>
+              </q-select>
             </div>
-          </q-item-section>
-        </q-item>
-      </q-card-section>
-
-      <!-- Seção: Convites Pendentes para Aprovação -->
-      <template v-if="convitesPendentes.length > 0">
-        <q-separator />
-
-        <q-card-section>
-          <div class="row items-center q-mb-sm">
-            <div class="text-subtitle2 text-weight-medium">Convites Pendentes</div>
-            <q-space />
-            <q-badge color="orange" :label="convitesPendentes.length" />
+            <div class="col-12 col-sm-auto">
+              <q-btn
+                color="primary"
+                label="Enviar convite"
+                icon="send"
+                :loading="loadingConvite"
+                :disable="!novoEmail.trim()"
+                @click="enviarConvite"
+                unelevated
+                no-caps
+                class="invite-button full-width"
+              />
+            </div>
           </div>
-          <div class="text-caption text-grey q-mb-sm">Você recebeu convites para acessar dados de outras pessoas.</div>
+        </div>
 
-          <q-item
-            v-for="convite in convitesPendentes"
-            :key="convite.id"
-            class="q-px-none"
-          >
+        <div class="row items-center q-mb-sm">
+          <div class="text-subtitle1 text-weight-bold">Pessoas com acesso a minha conta</div>
+          <q-space />
+          <q-badge
+            outline
+            color="primary"
+            :label="`${compartilhamentosAtivos.length + 1} ${compartilhamentosAtivos.length === 0 ? 'pessoa' : 'pessoas'}`"
+            class="q-px-sm q-py-xs"
+          />
+        </div>
+        <q-list bordered separator class="access-list">
+          <q-item class="q-py-md">
             <q-item-section avatar>
-              <q-avatar color="orange" text-color="white">
-                <q-icon name="mail" />
-              </q-avatar>
+              <q-avatar color="primary" text-color="white" icon="person" />
             </q-item-section>
             <q-item-section>
-              <q-item-label>{{ convite.proprietarioNome }}</q-item-label>
-              <q-item-label caption>{{ convite.proprietarioEmail }} • {{ permissaoTexto(convite.permissao) }}</q-item-label>
+              <q-item-label class="text-weight-medium"
+                >{{ nomeUsuario }} <span class="text-grey-7">(você)</span></q-item-label
+              >
+              <q-item-label caption>{{ emailUsuario }}</q-item-label>
             </q-item-section>
             <q-item-section side>
-              <div class="row items-center q-gutter-xs">
-                <q-btn
-                  flat
-                  dense
+              <q-badge outline color="primary" label="Proprietário" class="q-px-sm q-py-xs" />
+            </q-item-section>
+          </q-item>
+
+          <q-item v-for="comp in compartilhamentosAtivos" :key="comp.id" class="q-py-md">
+            <q-item-section avatar>
+              <q-avatar
+                :color="$q.dark.isActive ? 'grey-9' : 'blue-1'"
+                text-color="primary"
+                icon="person"
+              />
+            </q-item-section>
+            <q-item-section>
+              <q-item-label class="text-weight-medium">{{ comp.convidadoEmail }}</q-item-label>
+              <q-item-label caption class="q-mt-xs">
+                <q-badge
+                  :color="corStatus(comp.status)"
                   rounded
-                  label="Aceitar"
-                  color="positive"
-                  :loading="loadingResposta === convite.id"
-                  @click="responderConviteModal(convite.id, true)"
+                  :label="statusTexto(comp.status)"
+                  class="q-px-sm q-py-xs"
+                />
+              </q-item-label>
+            </q-item-section>
+            <q-item-section side>
+              <div class="row no-wrap items-center q-gutter-xs">
+                <q-select
+                  v-if="comp.status === StatusConvite.Aceito"
+                  :model-value="comp.permissao"
+                  :options="opcoesPermissao"
+                  outlined
+                  dense
+                  emit-value
+                  map-options
+                  class="permission-select"
+                  :dark="$q.dark.isActive"
+                  @update:model-value="(val) => atualizarPermissao(comp.id, val)"
                 />
                 <q-btn
                   flat
                   dense
-                  rounded
-                  label="Recusar"
+                  round
+                  icon="delete_outline"
                   color="negative"
-                  :loading="loadingResposta === convite.id"
-                  @click="responderConviteModal(convite.id, false)"
-                />
+                  @click="confirmarRevogacao(comp.id)"
+                >
+                  <q-tooltip>Remover acesso</q-tooltip>
+                </q-btn>
               </div>
             </q-item-section>
           </q-item>
-        </q-card-section>
-      </template>
+        </q-list>
 
-      <q-card-actions align="right" class="q-px-md q-py-md">
+        <div v-if="convitesPendentes.length > 0" class="q-mt-lg">
+          <div class="row items-center q-mb-xs">
+            <div class="text-subtitle1 text-weight-bold">Convites recebidos</div>
+            <q-space />
+            <q-badge color="orange" :label="convitesPendentes.length" />
+          </div>
+          <div class="text-caption text-grey-7 q-mb-md">
+            Pessoas que convidaram você para acessar os dados delas.
+          </div>
+
+          <q-list bordered separator class="access-list">
+            <q-item v-for="convite in convitesPendentes" :key="convite.id" class="q-py-md">
+              <q-item-section avatar>
+                <q-avatar color="orange-2" text-color="orange-10" icon="mail" />
+              </q-item-section>
+              <q-item-section>
+                <q-item-label class="text-weight-medium">{{
+                  convite.proprietarioNome
+                }}</q-item-label>
+                <q-item-label caption>{{ convite.proprietarioEmail }}</q-item-label>
+                <q-item-label caption class="q-mt-xs">
+                  <q-badge outline color="info" class="q-px-sm q-py-xs">
+                    <q-icon :name="iconePermissao(convite.permissao)" size="xs" class="q-mr-xs" />
+                    {{ permissaoTexto(convite.permissao) }}
+                  </q-badge>
+                </q-item-label>
+              </q-item-section>
+              <q-item-section side>
+                <div class="row items-center q-gutter-xs">
+                  <q-btn
+                    flat
+                    dense
+                    rounded
+                    label="Aceitar"
+                    color="positive"
+                    no-caps
+                    :loading="loadingResposta === convite.id"
+                    @click="responderConviteModal(convite.id, true)"
+                  />
+                  <q-btn
+                    flat
+                    dense
+                    rounded
+                    label="Recusar"
+                    color="negative"
+                    no-caps
+                    :loading="loadingResposta === convite.id"
+                    @click="responderConviteModal(convite.id, false)"
+                  />
+                </div>
+              </q-item-section>
+            </q-item>
+          </q-list>
+        </div>
+      </q-card-section>
+
+      <q-separator />
+      <q-card-actions align="right" class="q-pa-md">
         <q-btn
           unelevated
           color="primary"
           label="Concluído"
+          no-caps
+          class="done-button"
           v-close-popup
         />
       </q-card-actions>
@@ -190,7 +244,7 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  tituloContexto: 'Lista de tarefas'
+  tituloContexto: 'Lista de tarefas',
 });
 
 const emit = defineEmits<{
@@ -203,7 +257,7 @@ const $q = useQuasar();
 
 const showDialog = computed({
   get: () => props.modelValue,
-  set: (val) => emit('update:modelValue', val)
+  set: (val) => emit('update:modelValue', val),
 });
 
 const novoEmail = ref('');
@@ -213,19 +267,15 @@ const loadingResposta = ref<string | null>(null);
 
 const opcoesPermissao = [
   { label: 'Visualização', value: NivelPermissao.Visualizar },
-  { label: 'Edição', value: NivelPermissao.Editar }
+  { label: 'Edição', value: NivelPermissao.Editar },
 ];
 
 const nomeUsuario = computed(() => userStore.getName() || 'Usuário');
 const emailUsuario = computed(() => userStore.getEmail() || '');
 
-const compartilhamentosAtivos = computed(() =>
-  compartilhamentoStore.meusCompartilhamentos
-);
+const compartilhamentosAtivos = computed(() => compartilhamentoStore.meusCompartilhamentos);
 
-const convitesPendentes = computed(() =>
-  compartilhamentoStore.convitesPendentes
-);
+const convitesPendentes = computed(() => compartilhamentoStore.convitesPendentes);
 
 function permissaoTexto(permissao: NivelPermissao): string {
   return permissao === NivelPermissao.Editar ? 'Edição' : 'Visualização';
@@ -244,16 +294,34 @@ function statusTexto(status: StatusConvite): string {
   }
 }
 
+function corStatus(status: StatusConvite): string {
+  switch (status) {
+    case StatusConvite.Pendente:
+      return 'warning';
+    case StatusConvite.Aceito:
+      return 'positive';
+    case StatusConvite.Recusado:
+      return 'negative';
+    default:
+      return 'grey';
+  }
+}
+
+function iconePermissao(permissao: NivelPermissao): string {
+  return permissao === NivelPermissao.Editar ? 'edit' : 'visibility';
+}
+
 async function enviarConvite() {
-  if (!novoEmail.value) return;
+  const email = novoEmail.value.trim();
+  if (!email) return;
 
   loadingConvite.value = true;
   try {
-    await compartilhamentoStore.convidar(novoEmail.value, novaPermissao.value);
+    await compartilhamentoStore.convidar(email, novaPermissao.value);
     $q.notify({
       type: 'positive',
       message: 'Convite enviado com sucesso!',
-      position: 'top'
+      position: 'top',
     });
     novoEmail.value = '';
     novaPermissao.value = NivelPermissao.Visualizar;
@@ -261,7 +329,7 @@ async function enviarConvite() {
     $q.notify({
       type: 'negative',
       message: error.response?.data?.errors?.[0] || 'Erro ao enviar convite',
-      position: 'top'
+      position: 'top',
     });
   } finally {
     loadingConvite.value = false;
@@ -274,13 +342,13 @@ async function atualizarPermissao(compartilhamentoId: string, novaPermissao: Niv
     $q.notify({
       type: 'positive',
       message: 'Permissão atualizada com sucesso!',
-      position: 'top'
+      position: 'top',
     });
   } catch (error) {
     $q.notify({
       type: 'negative',
       message: 'Erro ao atualizar permissão',
-      position: 'top'
+      position: 'top',
     });
   }
 }
@@ -292,14 +360,14 @@ function confirmarRevogacao(compartilhamentoId: string) {
     cancel: {
       label: 'Cancelar',
       flat: true,
-      color: 'grey'
+      color: 'grey',
     },
     ok: {
       label: 'Remover',
       flat: true,
-      color: 'negative'
+      color: 'negative',
     },
-    persistent: true
+    persistent: true,
   }).onOk(() => {
     void (async () => {
       try {
@@ -307,13 +375,13 @@ function confirmarRevogacao(compartilhamentoId: string) {
         $q.notify({
           type: 'positive',
           message: 'Acesso removido com sucesso!',
-          position: 'top'
+          position: 'top',
         });
       } catch (error) {
         $q.notify({
           type: 'negative',
           message: 'Erro ao remover acesso',
-          position: 'top'
+          position: 'top',
         });
       }
     })();
@@ -327,13 +395,13 @@ async function responderConviteModal(conviteId: string, aceitar: boolean) {
     $q.notify({
       type: 'positive',
       message: aceitar ? 'Convite aceito com sucesso!' : 'Convite recusado.',
-      position: 'top'
+      position: 'top',
     });
   } catch (error) {
     $q.notify({
       type: 'negative',
       message: 'Erro ao responder convite',
-      position: 'top'
+      position: 'top',
     });
   } finally {
     loadingResposta.value = null;
@@ -347,7 +415,74 @@ function onHide() {
 </script>
 
 <style scoped>
-.q-card {
+.compartilhamento-modal {
+  width: 720px;
+  max-width: 92vw;
+  max-height: 88vh;
+  border-radius: 16px;
+}
+
+.convite-panel {
+  border: 1px solid;
+  border-radius: 16px;
+}
+
+.convite-panel--light {
+  background: #f8f8ff;
+  border-color: rgba(29, 22, 156, 0.14);
+}
+
+.convite-panel--dark {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.permissao-convite {
+  width: 180px;
+}
+
+.invite-button {
+  min-height: 40px;
   border-radius: 8px;
+}
+
+.access-list {
+  overflow: hidden;
+  border-radius: 12px;
+}
+
+.permission-select {
+  min-width: 132px;
+}
+
+.done-button {
+  min-width: 112px;
+  border-radius: 8px;
+}
+
+@media (max-width: 599px) {
+  .compartilhamento-modal {
+    width: 100%;
+    max-width: 100%;
+    max-height: 100vh;
+    border-radius: 16px 16px 0 0;
+    align-self: flex-end;
+  }
+
+  .permissao-convite {
+    width: auto;
+  }
+
+  .access-list :deep(.q-item) {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .access-list :deep(.q-item__section--side) {
+    width: 100%;
+    align-items: flex-end;
+    padding-left: 56px;
+    padding-top: 8px;
+  }
 }
 </style>

--- a/src/components/Compartilhamento/ContextoSelector.vue
+++ b/src/components/Compartilhamento/ContextoSelector.vue
@@ -1,23 +1,34 @@
 <template>
-  <div class="row no-wrap items-center q-gutter-sm">
+  <div class="contexto-selector-wrapper row no-wrap items-center q-gutter-sm">
     <!-- Seletor de Contexto -->
-    <div 
-      class="row no-wrap items-center text-grey-9 rounded-borders cursor-pointer q-py-xs q-pl-md q-pr-xs transition-hover relative-position" 
-      style="border: 1px solid transparent; background-color: #ffffff"
+    <q-btn
+      flat
+      no-caps
+      :loading="loading"
+      :disable="loading"
+      class="contexto-selector row no-wrap items-center rounded-borders cursor-pointer q-py-xs q-pl-md q-pr-xs transition-hover relative-position"
+      :class="$q.dark.isActive ? 'bg-grey-9 text-white' : 'bg-white text-grey-9'"
     >
-      <div class="row items-center" @click="toggleMenu">
-          <q-icon :name="contextoIcon" size="20px" class="q-mr-sm" />
-          <span class="text-subtitle2 text-weight-medium ellipsis" style="max-width: 150px">{{ contextoLabel }}</span>
+      <div class="row no-wrap items-center">
+        <q-icon :name="contextoIcon" size="20px" class="q-mr-sm" />
+        <span class="contexto-label text-subtitle2 text-weight-medium ellipsis">{{
+          contextoLabel
+        }}</span>
       </div>
 
-      <div class="q-mx-sm" style="width: 1px; height: 24px; background-color: rgba(0,0,0,0.1)"></div>
+      <div class="contexto-divider q-mx-sm"></div>
 
-      <q-icon name="arrow_drop_down" size="24px" @click.stop="toggleMenu" />
+      <q-icon name="arrow_drop_down" size="24px" />
 
-      <q-menu v-model="menuOpen" fit anchor="bottom right" self="top right" :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'">
+      <q-menu
+        fit
+        anchor="bottom right"
+        self="top right"
+        :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
+      >
         <q-list style="min-width: 220px">
           <q-item-label header class="text-grey-7">Selecionar Contexto</q-item-label>
-          
+
           <q-item
             v-for="opcao in opcoesContexto"
             :key="opcao.value"
@@ -40,11 +51,7 @@
           </q-item>
         </q-list>
       </q-menu>
-      
-      <q-inner-loading :showing="loading" class="rounded-borders">
-          <q-spinner size="20px" color="primary" />
-      </q-inner-loading>
-    </div>
+    </q-btn>
 
     <!-- Botão de Compartilhamento -->
     <q-btn
@@ -66,10 +73,7 @@
     </q-btn>
 
     <!-- Modal de Compartilhamento -->
-    <compartilhamento-modal
-      v-model="showCompartilhamentoModal"
-      titulo-contexto="Meus Dados"
-    />
+    <compartilhamento-modal v-model="showCompartilhamentoModal" titulo-contexto="Meus Dados" />
   </div>
 </template>
 
@@ -84,12 +88,13 @@ const $q = useQuasar();
 
 const loading = ref(false);
 const contextSelecionadoInternal = ref<string | null>(null);
-const menuOpen = ref(false);
 const showCompartilhamentoModal = ref(false);
 
 const contextoSelecionado = computed({
   get: () => contextSelecionadoInternal.value,
-  set: (val) => { contextSelecionadoInternal.value = val; }
+  set: (val) => {
+    contextSelecionadoInternal.value = val;
+  },
 });
 
 const opcoesContexto = computed(() => {
@@ -97,16 +102,16 @@ const opcoesContexto = computed(() => {
     {
       label: 'Meus Dados',
       value: '',
-      icon: 'person'
-    }
+      icon: 'person',
+    },
   ];
 
   // Adicionar compartilhamentos aceitos
-  compartilhamentoStore.compartilhamentosAceitos.forEach(comp => {
+  compartilhamentoStore.compartilhamentosAceitos.forEach((comp) => {
     opcoes.push({
       label: `Dados de ${comp.proprietarioNome}`,
       value: comp.proprietarioId,
-      icon: 'share'
+      icon: 'share',
     });
   });
 
@@ -114,28 +119,22 @@ const opcoesContexto = computed(() => {
 });
 
 const contextoLabel = computed(() => {
-    const selected = opcoesContexto.value.find(o => o.value === contextoSelecionado.value);
-    // Se o selecionado for "Meus Dados" (valor vazio), podemos exibir "Minha Conta" ou manter "Meus Dados".
-    // Mas para imitar o layout "Compartilhar" do exemplo, talvez devêssemos usar "Compartilhar" como título fixo?
-    // O usuário pediu layout do botão. Vou manter o label dinâmico para usabilidade, mas com o ícone.
-    // Se for um contexto compartilhado, mostramos o nome.
-    if (selected) {
-        return selected.value === '' ? 'Meus Dados' : selected.label;
-    }
-    return 'Selecione';
+  const selected = opcoesContexto.value.find((o) => o.value === contextoSelecionado.value);
+  // Se o selecionado for "Meus Dados" (valor vazio), podemos exibir "Minha Conta" ou manter "Meus Dados".
+  // Mas para imitar o layout "Compartilhar" do exemplo, talvez devêssemos usar "Compartilhar" como título fixo?
+  // O usuário pediu layout do botão. Vou manter o label dinâmico para usabilidade, mas com o ícone.
+  // Se for um contexto compartilhado, mostramos o nome.
+  if (selected) {
+    return selected.value === '' ? 'Meus Dados' : selected.label;
+  }
+  return 'Selecione';
 });
 
 const contextoIcon = computed(() => {
-    const selected = opcoesContexto.value.find(o => o.value === contextoSelecionado.value);
-    if (selected && selected.value === '') return 'person'; 
-    return 'share';
+  const selected = opcoesContexto.value.find((o) => o.value === contextoSelecionado.value);
+  if (selected && selected.value === '') return 'person';
+  return 'share';
 });
-
-function toggleMenu() {
-    if (!loading.value) {
-        menuOpen.value = !menuOpen.value;
-    }
-}
 
 function abrirModalCompartilhamento() {
   showCompartilhamentoModal.value = true;
@@ -144,7 +143,7 @@ function abrirModalCompartilhamento() {
 function trocarContexto(proprietarioId: string | null) {
   // Se já estiver selecionado, não faz nada
   if (proprietarioId === contextoSelecionado.value) return;
-  
+
   loading.value = true;
   try {
     if (proprietarioId === null || proprietarioId === '') {
@@ -153,7 +152,7 @@ function trocarContexto(proprietarioId: string | null) {
     } else {
       // Ativar contexto compartilhado
       const compartilhamento = compartilhamentoStore.compartilhamentosAceitos.find(
-        c => c.proprietarioId === proprietarioId
+        (c) => c.proprietarioId === proprietarioId,
       );
       if (compartilhamento) {
         compartilhamentoStore.ativarContexto(compartilhamento);
@@ -167,7 +166,7 @@ function trocarContexto(proprietarioId: string | null) {
     console.error('Erro ao trocar contexto:', error);
     $q.notify({
       type: 'negative',
-      message: 'Erro ao trocar visualização. Tente novamente.'
+      message: 'Erro ao trocar visualização. Tente novamente.',
     });
     loading.value = false;
   }
@@ -184,10 +183,43 @@ onMounted(() => {
 </script>
 
 <style scoped>
-.transition-hover {
-  transition: background-color 0.3s ease;
+.contexto-label {
+  max-width: 150px;
 }
+
+.contexto-divider {
+  width: 1px;
+  height: 24px;
+  background-color: currentColor;
+  opacity: 0.12;
+}
+
+.transition-hover {
+  transition:
+    filter 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
 .transition-hover:hover {
   filter: brightness(0.95);
+}
+
+@media (max-width: 599px) {
+  .contexto-selector-wrapper {
+    gap: 4px;
+  }
+
+  .contexto-selector {
+    padding-left: 8px;
+  }
+
+  .contexto-label {
+    max-width: 82px;
+  }
+
+  .contexto-divider {
+    margin-left: 4px;
+    margin-right: 2px;
+  }
 }
 </style>

--- a/src/components/Configuracoes/CategoriaConfig.vue
+++ b/src/components/Configuracoes/CategoriaConfig.vue
@@ -1,122 +1,136 @@
 <template>
   <div class="categoria-principal column full-height">
-    <!-- Header / Description -->
-    <div class="q-mb-md">
-      <p class="descricao q-mt-sm q-mb-none">
-        A categorização é essencial para organizar e classificar nossos gastos diários,
-        proporcionando uma visão clara e estruturada das despesas.
-      </p>
-    </div>
-
-    <!-- Banner Modo Compartilhado -->
-    <BannerModoCompartilhado />
-    <!-- Controls Toolbar -->
-    <div class="row items-center q-mb-md justify-between wrap q-gutter-y-sm">
-      <!-- Tabs for Category Type -->
-      <q-tabs
-        v-model="tipoCategoriaSelecionada"
-        dense
-        class="text-grey"
-        active-color="primary"
-        indicator-color="primary"
-        align="left"
-        narrow-indicator
-        @update:model-value="() => obterCategorias()"
-      >
-        <q-tab
-          v-for="opt in options"
-          :key="opt.value"
-          :name="opt.value"
-          :label="opt.label"
-          no-caps
-        />
-      </q-tabs>
-
-      <!-- Actions -->
-      <div class="row q-gutter-sm items-center">
-        <q-input
-          v-model="filter"
-          dense
-          outlined
-          placeholder="Pesquisar"
-          class="rounded-borders"
-          :class="$q.dark.isActive ? 'bg-grey-9' : 'bg-white'"
-          :dark="$q.dark.isActive"
-          style="min-width: 200px"
-        >
-          <template v-slot:prepend>
-            <q-icon name="search" size="xs" />
-          </template>
-        </q-input>
-
-        <q-btn
-          color="primary"
-          label="Criar Nova"
-          no-caps
-          icon="add"
-          unelevated
-          @click="openModalCriarCategoria"
-        />
+    <!-- Cabeçalho Padronizado -->
+    <div class="q-mb-md flex items-center q-gutter-x-sm">
+      <q-avatar color="primary" text-color="white" icon="category" size="48px" font-size="24px" />
+      <div>
+        <div class="text-h5 text-weight-bold">Categorias</div>
+        <div class="text-caption text-grey-7">
+          Gerencie as categorias de rendimentos, despesas e investimentos para classificar seu orçamento.
+        </div>
       </div>
     </div>
 
-    <!-- Table -->
-    <div class="col">
-      <q-table
-        flat
-        :rows="categorias || []"
-        :columns="columns"
-        row-key="id"
-        :loading="loading"
-        :pagination="{ rowsPerPage: 7 }"
-        :filter="filter"
-        no-data-label="Nenhuma categoria encontrada"
-        class="sticky-header-table"
-      >
-        <template v-slot:body-cell-tipo="props">
-          <q-td :props="props" auto-width>
-            <q-icon
-              :name="obterIconeCategoria(props.value).icone"
-              :color="obterIconeCategoria(props.value).cor"
-              size="24px"
-            />
-            <span class="q-ml-sm">{{ obterIconeCategoria(props.value).descricao }}</span>
-          </q-td>
-        </template>
+    <!-- Banner Modo Compartilhado -->
+    <BannerModoCompartilhado class="q-mb-md" />
 
-        <template v-slot:body-cell-actions="props">
-          <q-td :props="props" auto-width>
-            <div class="text-grey-8 q-gutter-xs">
-              <q-btn
-                size="12px"
-                flat
-                dense
-                round
-                icon="edit"
-                @click="() => modalEditarCategoria(props.row)"
+    <!-- Card de Conteúdo -->
+    <q-card flat bordered class="rounded-borders-xl shadow-1 col column overflow-hidden">
+      <q-card-section class="q-pa-md">
+        <!-- Controls Toolbar -->
+        <div class="row items-center justify-between wrap q-gutter-y-sm">
+          <!-- Tabs for Category Type -->
+          <q-tabs
+            v-model="tipoCategoriaSelecionada"
+            dense
+            class="text-grey"
+            active-color="primary"
+            indicator-color="primary"
+            align="left"
+            narrow-indicator
+            @update:model-value="() => obterCategorias()"
+          >
+            <q-tab
+              v-for="opt in options"
+              :key="opt.value"
+              :name="opt.value"
+              :label="opt.label"
+              no-caps
+            />
+          </q-tabs>
+
+          <!-- Actions -->
+          <div class="row q-gutter-sm items-center">
+            <q-input
+              v-model="filter"
+              dense
+              outlined
+              placeholder="Pesquisar"
+              class="rounded-borders"
+              :class="$q.dark.isActive ? 'bg-grey-9' : 'bg-white'"
+              :dark="$q.dark.isActive"
+              style="min-width: 200px"
+            >
+              <template v-slot:prepend>
+                <q-icon name="search" size="xs" />
+              </template>
+            </q-input>
+
+            <q-btn
+              color="primary"
+              label="Criar Nova"
+              no-caps
+              icon="add"
+              unelevated
+              @click="openModalCriarCategoria"
+            />
+          </div>
+        </div>
+      </q-card-section>
+
+      <q-separator />
+
+      <!-- Table Section -->
+      <div class="col overflow-auto">
+        <q-table
+          flat
+          :rows="categorias || []"
+          :columns="columns"
+          row-key="id"
+          :loading="loading"
+          :pagination="{ rowsPerPage: 7 }"
+          :filter="filter"
+          no-data-label="Nenhuma categoria encontrada"
+          class="sticky-header-table no-border"
+          :card-class="$q.dark.isActive ? 'bg-dark' : 'bg-white'"
+        >
+          <template v-slot:body-cell-tipo="props">
+            <q-td :props="props" auto-width>
+              <q-icon
+                :name="obterIconeCategoria(props.value).icone"
+                :color="obterIconeCategoria(props.value).cor"
+                size="24px"
               />
-              <q-btn
-                size="12px"
-                flat
-                dense
-                round
-                icon="delete"
-                @click="() => excluirCategoria(props.row)"
-              />
-            </div>
-          </q-td>
-        </template>
-      </q-table>
-    </div>
+              <span class="q-ml-sm">{{ obterIconeCategoria(props.value).descricao }}</span>
+            </q-td>
+          </template>
+
+          <template v-slot:body-cell-actions="props">
+            <q-td :props="props" auto-width>
+              <div class="text-grey-8 q-gutter-xs">
+                <q-btn
+                  size="12px"
+                  flat
+                  dense
+                  round
+                  icon="edit"
+                  :color="$q.dark.isActive ? 'grey-4' : 'grey-8'"
+                  @click="() => modalEditarCategoria(props.row)"
+                />
+                <q-btn
+                  size="12px"
+                  flat
+                  dense
+                  round
+                  icon="delete"
+                  :color="$q.dark.isActive ? 'grey-4' : 'grey-8'"
+                  @click="() => excluirCategoria(props.row)"
+                />
+              </div>
+            </q-td>
+          </template>
+        </q-table>
+      </div>
+    </q-card>
   </div>
 
   <!-- modal Cadastro Categoria -->
   <q-dialog v-model="openModalCreateCategoria">
-    <q-card style="width: 330px">
+    <q-card style="width: 330px" class="rounded-borders-xl">
       <q-form @submit="criarCategoria">
         <q-card-section>
-          <section class="q-mb-sm">
-            <span class="text-subtitle1">Nova categoria</span>
+          <section class="q-mb-md">
+            <span class="text-subtitle1 text-weight-bold">Nova Categoria</span>
           </section>
           <q-input
             filled
@@ -124,12 +138,13 @@
             label="Nome"
             autogrow
             :rules="[(val:any) => (val && val.length > 0) || 'Nome é obrigatório!']"
+            class="q-mb-sm"
           />
           <div
             class="q-pa-sm rounded-borders"
             :class="$q.dark.isActive ? 'bg-grey-9' : 'bg-grey-2'"
           >
-            Tipo da Categoria:
+            <div class="text-caption text-weight-medium q-mb-xs">Tipo da Categoria:</div>
             <q-option-group
               v-model="categoriaCreate.tipo"
               :options="options"
@@ -138,9 +153,9 @@
             />
           </div>
         </q-card-section>
-        <q-card-actions align="between" :class="$q.dark.isActive ? 'bg-grey-9' : 'bg-white'">
-          <q-btn label="Fechar" no-caps flat dense v-close-popup />
-          <q-btn flat no-caps label="Adicionar" type="submit" :loading="loading" />
+        <q-card-actions align="between" class="q-px-md q-pb-md" :class="$q.dark.isActive ? 'bg-grey-9' : 'bg-white'">
+          <q-btn label="Fechar" no-caps flat dense v-close-popup color="grey-7" />
+          <q-btn unelevated no-caps label="Adicionar" type="submit" color="primary" :loading="loading" style="border-radius: 8px;" />
         </q-card-actions>
       </q-form>
     </q-card>
@@ -295,30 +310,24 @@ function openModalCriarCategoria() {
 </script>
 
 <style scoped>
-/* Conteúdo principal */
 .categoria-principal {
   flex: 1;
   overflow-y: auto;
 }
 
-.categoria-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 20px;
+.rounded-borders-xl {
+  border-radius: 16px;
 }
 
-.categoria-titulo {
-  font-size: 22px;
-  font-weight: 500;
-  color: var(--text-primary);
+.shadow-1 {
+  transition: box-shadow 0.3s ease;
 }
 
-.descricao {
-  color: var(--text-secondary);
+.shadow-1:hover {
+  box-shadow: 0 6px 20px v-bind('$q.dark.isActive ? "rgba(0,0,0,0.4)" : "rgba(0,0,0,0.08)"') !important;
 }
 
-.tabela-header {
-  color: var(--text-primary);
+.no-border {
+  border: none !important;
 }
 </style>

--- a/src/components/Configuracoes/CategoriaConfig.vue
+++ b/src/components/Configuracoes/CategoriaConfig.vue
@@ -125,40 +125,96 @@
     </q-card>
   </div>
 
-  <!-- modal Cadastro Categoria -->
-  <q-dialog v-model="openModalCreateCategoria">
-    <q-card style="width: 330px" class="rounded-borders-xl">
-      <q-form @submit="criarCategoria">
-        <q-card-section>
-          <section class="q-mb-md">
-            <span class="text-subtitle1 text-weight-bold">Nova Categoria</span>
-          </section>
-          <q-input
-            filled
-            v-model="categoriaCreate.nome"
-            label="Nome"
-            autogrow
-            :rules="[(val:any) => (val && val.length > 0) || 'Nome é obrigatório!']"
-            class="q-mb-sm"
-          />
-          <div
-            class="q-pa-sm rounded-borders"
-            :class="$q.dark.isActive ? 'bg-grey-9' : 'bg-grey-2'"
-          >
-            <div class="text-caption text-weight-medium q-mb-xs">Tipo da Categoria:</div>
-            <q-option-group
-              v-model="categoriaCreate.tipo"
-              :options="options"
+  <!-- Modal de cadastro e edição de categoria -->
+  <q-dialog v-model="openModalCategoria" @hide="resetarFormularioCategoria">
+    <q-card class="categoria-modal">
+      <q-card-section class="row items-center q-pb-none">
+        <div>
+          <div class="text-h6 text-bold">
+            {{ modalEdicao ? 'Editar categoria' : 'Criar nova categoria' }}
+          </div>
+          <div class="text-caption text-grey-7">
+            {{
+              modalEdicao
+                ? 'Altere o nome da categoria selecionada.'
+                : 'Adicione uma categoria para organizar seus lançamentos.'
+            }}
+          </div>
+        </div>
+        <q-space />
+        <q-btn v-close-popup flat round dense icon="close" aria-label="Fechar modal" />
+      </q-card-section>
+
+      <q-card-section>
+        <q-form class="q-gutter-md" @submit="salvarCategoria">
+          <div>
+            <label class="text-subtitle2 text-bold q-mb-xs block">Nome da categoria</label>
+            <q-input
+              v-model="categoriaForm.nome"
+              outlined
+              rounded
+              dense
+              autofocus
+              maxlength="60"
+              placeholder="Ex: Salário, Mercado, Reserva"
+              :rules="[(val: string) => !!val?.trim() || 'Informe o nome da categoria']"
+            >
+              <template #prepend>
+                <q-icon name="label_outline" size="20px" />
+              </template>
+            </q-input>
+          </div>
+
+          <div>
+            <div class="row items-center justify-between q-mb-sm">
+              <label class="text-subtitle2 text-bold">Tipo da categoria</label>
+              <span v-if="modalEdicao" class="text-caption text-grey-7">Não pode ser alterado</span>
+            </div>
+
+            <div class="categoria-type-grid">
+              <div
+                v-for="option in categoryOptions"
+                :key="option.value"
+                class="categoria-type-option"
+                :class="{
+                  'categoria-type-option--selected': categoriaForm.tipo === option.value,
+                  'categoria-type-option--disabled': modalEdicao,
+                }"
+                role="button"
+                tabindex="0"
+                :aria-pressed="categoriaForm.tipo === option.value"
+                :aria-disabled="modalEdicao"
+                @click="selecionarTipoCategoria(option.value)"
+                @keydown.enter="selecionarTipoCategoria(option.value)"
+                @keydown.space.prevent="selecionarTipoCategoria(option.value)"
+              >
+                <q-icon :name="option.icone" :color="option.cor" size="24px" />
+                <span class="text-caption text-weight-medium">{{ option.label }}</span>
+                <span
+                  v-if="categoriaForm.tipo === option.value"
+                  class="categoria-type-option__check"
+                >
+                  <q-icon name="check" color="white" size="13px" />
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div class="categoria-modal__actions row justify-end q-gutter-sm q-mt-lg">
+            <q-btn v-close-popup flat no-caps label="Cancelar" color="grey-7" />
+            <q-btn
+              unelevated
+              rounded
+              no-caps
+              type="submit"
               color="primary"
-              right-label
+              :icon="modalEdicao ? 'save' : 'add'"
+              :label="modalEdicao ? 'Salvar' : 'Criar categoria'"
+              :loading="modalLoading"
             />
           </div>
-        </q-card-section>
-        <q-card-actions align="between" class="q-px-md q-pb-md" :class="$q.dark.isActive ? 'bg-grey-9' : 'bg-white'">
-          <q-btn label="Fechar" no-caps flat dense v-close-popup color="grey-7" />
-          <q-btn unelevated no-caps label="Adicionar" type="submit" color="primary" :loading="loading" style="border-radius: 8px;" />
-        </q-card-actions>
-      </q-form>
+        </q-form>
+      </q-card-section>
     </q-card>
   </q-dialog>
 </template>
@@ -169,35 +225,46 @@ import type { CategoriaResult, CreateCategoriaDTO } from 'src/Model/Categoria';
 import { TipoCategoriaETransacao } from 'src/Model/Categoria';
 import obterCategoriaService from 'src/services/CategoriaService';
 import BannerModoCompartilhado from 'src/components/Compartilhamento/BannerModoCompartilhado.vue';
-import { onMounted, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 
 // Variaveis
 const categoriaService = obterCategoriaService();
 const categorias = ref<CategoriaResult[]>();
 const $q = useQuasar();
-const openModalCreateCategoria = ref(false);
+const openModalCategoria = ref(false);
+const categoriaEmEdicao = ref<CategoriaResult>();
 const loading = ref(false);
+const modalLoading = ref(false);
 const tipoCategoriaSelecionada = ref(TipoCategoriaETransacao.Rendimento);
-const categoriaCreate = ref<CreateCategoriaDTO>({
+const categoriaForm = ref<CreateCategoriaDTO>({
   nome: '',
   tipo: tipoCategoriaSelecionada.value,
 });
 const filter = ref('');
 
-const options = [
+const categoryOptions = [
   {
     label: 'Rendimentos',
     value: TipoCategoriaETransacao.Rendimento,
+    icone: 'trending_up',
+    cor: 'green',
   },
   {
     label: 'Despesas',
     value: TipoCategoriaETransacao.Despesa,
+    icone: 'trending_down',
+    cor: 'red',
   },
   {
     label: 'Investimentos',
     value: TipoCategoriaETransacao.Investimento,
+    icone: 'show_chart',
+    cor: 'primary',
   },
 ];
+
+const options = categoryOptions.map(({ label, value }) => ({ label, value }));
+const modalEdicao = computed(() => !!categoriaEmEdicao.value);
 
 const columns: any[] = [
   {
@@ -235,12 +302,28 @@ async function obterCategorias() {
   }
 }
 
-async function criarCategoria() {
-  await categoriaService.adicionar(categoriaCreate.value);
-  tipoCategoriaSelecionada.value = categoriaCreate.value.tipo;
-  categoriaCreate.value.nome = '';
-  openModalCreateCategoria.value = false;
-  await obterCategorias();
+async function salvarCategoria() {
+  modalLoading.value = true;
+  try {
+    if (categoriaEmEdicao.value) {
+      const categoriaAtualizada = await categoriaService.atualizar({
+        id: categoriaEmEdicao.value.id,
+        nome: categoriaForm.value.nome.trim(),
+      });
+      categoriaEmEdicao.value.nome = categoriaAtualizada.nome;
+    } else {
+      await categoriaService.adicionar({
+        nome: categoriaForm.value.nome.trim(),
+        tipo: categoriaForm.value.tipo,
+      });
+      tipoCategoriaSelecionada.value = categoriaForm.value.tipo;
+      await obterCategorias();
+    }
+
+    openModalCategoria.value = false;
+  } finally {
+    modalLoading.value = false;
+  }
 }
 
 function excluirCategoria(categoria: CategoriaResult) {
@@ -281,32 +364,36 @@ function obterIconeCategoria(tipoCategoria: TipoCategoriaETransacao) {
   }
 }
 
+function selecionarTipoCategoria(tipo: TipoCategoriaETransacao) {
+  if (!modalEdicao.value) {
+    categoriaForm.value.tipo = tipo;
+  }
+}
+
 function modalEditarCategoria(categoria: CategoriaResult) {
-  $q.dialog({
-    title: 'Editar categoria',
-    prompt: {
-      model: categoria.nome,
-      type: 'text',
-      isValid: (val) => val != null && val.length > 0,
-    },
-    cancel: true,
-    persistent: false,
-  }).onOk((nomeNovo: string) => {
-    if (nomeNovo === categoria.nome) return;
-    categoriaService
-      .atualizar({
-        id: categoria.id,
-        nome: nomeNovo,
-      })
-      .then((catecoriaResult: CategoriaResult) => {
-        categoria.nome = catecoriaResult.nome;
-      });
-  });
+  categoriaEmEdicao.value = categoria;
+  categoriaForm.value = {
+    nome: categoria.nome,
+    tipo: categoria.tipo,
+  };
+  openModalCategoria.value = true;
 }
 
 function openModalCriarCategoria() {
-  categoriaCreate.value.tipo = tipoCategoriaSelecionada.value;
-  openModalCreateCategoria.value = true;
+  categoriaEmEdicao.value = undefined;
+  categoriaForm.value = {
+    nome: '',
+    tipo: tipoCategoriaSelecionada.value,
+  };
+  openModalCategoria.value = true;
+}
+
+function resetarFormularioCategoria() {
+  categoriaEmEdicao.value = undefined;
+  categoriaForm.value = {
+    nome: '',
+    tipo: tipoCategoriaSelecionada.value,
+  };
 }
 </script>
 
@@ -338,5 +425,99 @@ function openModalCriarCategoria() {
 
 .categoria-tabs :deep(.q-tab--inactive) {
   opacity: 1;
+}
+
+.block {
+  display: block;
+}
+
+.categoria-modal {
+  width: min(460px, calc(100vw - 32px));
+  max-width: calc(100vw - 32px);
+  border-radius: 16px;
+}
+
+.categoria-type-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+.categoria-type-option {
+  position: relative;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  justify-content: center;
+  min-height: 76px;
+  padding: 10px 6px;
+  flex-direction: column;
+  color: inherit;
+  font: inherit;
+  text-align: center;
+  cursor: pointer;
+  background: transparent;
+  border: 2px solid transparent;
+  border-radius: 12px;
+  transition: all 0.2s;
+}
+
+.categoria-type-option:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.categoria-type-option--selected {
+  background: rgba(29, 22, 156, 0.05);
+  border-color: var(--q-primary);
+}
+
+.categoria-type-option--disabled {
+  cursor: default;
+}
+
+.categoria-type-option--disabled:hover {
+  background: transparent;
+}
+
+.categoria-type-option--disabled.categoria-type-option--selected:hover {
+  background: rgba(29, 22, 156, 0.05);
+}
+
+.categoria-type-option__check {
+  position: absolute;
+  top: 7px;
+  right: 7px;
+  display: grid;
+  width: 18px;
+  height: 18px;
+  background: var(--q-primary);
+  border-radius: 50%;
+  place-items: center;
+}
+
+:global(body.body--dark) .categoria-type-option:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+:global(body.body--dark) .categoria-type-option--selected,
+:global(body.body--dark) .categoria-type-option--disabled.categoria-type-option--selected:hover {
+  background: rgba(76, 68, 231, 0.16);
+}
+
+:global(body.body--dark) .categoria-type-option--disabled:hover {
+  background: transparent;
+}
+
+@media (max-width: 480px) {
+  .categoria-modal__actions {
+    flex-direction: column-reverse;
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .categoria-modal__actions :deep(.q-btn) {
+    width: 100%;
+    margin-left: 0;
+  }
 }
 </style>

--- a/src/components/Configuracoes/CategoriaConfig.vue
+++ b/src/components/Configuracoes/CategoriaConfig.vue
@@ -23,7 +23,7 @@
           <q-tabs
             v-model="tipoCategoriaSelecionada"
             dense
-            class="text-grey"
+            class="categoria-tabs"
             active-color="primary"
             indicator-color="primary"
             align="left"
@@ -35,6 +35,7 @@
               :key="opt.value"
               :name="opt.value"
               :label="opt.label"
+              class="text-weight-bold"
               no-caps
             />
           </q-tabs>
@@ -329,5 +330,13 @@ function openModalCriarCategoria() {
 
 .no-border {
   border: none !important;
+}
+
+.categoria-tabs {
+  color: v-bind('$q.dark.isActive ? "white" : "black"');
+}
+
+.categoria-tabs :deep(.q-tab--inactive) {
+  opacity: 1;
 }
 </style>

--- a/src/components/Configuracoes/InformacoesConta.vue
+++ b/src/components/Configuracoes/InformacoesConta.vue
@@ -1,64 +1,75 @@
 <template>
   <div class="q-pa-none">
     <div v-if="loading" class="q-pa-md"><q-spinner color="primary" /> Carregando...</div>
-    <div class="column q-gutter-md" v-else>
-      <div class="row items-center q-gutter-md">
-        <q-avatar size="70px" font-size="40px" color="primary" text-color="white">
+    <div class="column q-gutter-y-md" v-else>
+      <!-- Cabeçalho Padronizado -->
+      <div class="q-mb-md flex items-center q-gutter-x-sm">
+        <q-avatar color="primary" text-color="white" size="48px" font-size="20px">
           {{ usuario.nome ? usuario.nome.charAt(0).toUpperCase() : 'U' }}
         </q-avatar>
         <div>
-          <div class="text-h6 text-weight-bold">{{ usuario.nome }}</div>
-          <div class="text-subtitle2" :class="$q.dark.isActive ? 'text-grey-4' : 'text-grey-7'">
+          <div class="text-h5 text-weight-bold">{{ usuario.nome }}</div>
+          <div class="text-caption text-grey-7">
             {{ usuario.email }}
           </div>
         </div>
       </div>
 
-      <q-separator class="q-my-md" />
+      <!-- Card Aparência -->
+      <q-card flat bordered class="rounded-borders-xl shadow-1">
+        <q-card-section class="q-pb-none">
+          <div class="text-subtitle1 text-weight-bold flex items-center q-gutter-x-sm">
+            <q-icon name="palette" size="sm" color="primary" />
+            <span>Aparência</span>
+          </div>
+          <div class="text-caption text-grey-7 q-mt-xs">
+            Escolha como o FinanMap se apresenta para você.
+          </div>
+        </q-card-section>
 
-      <div>
-        <div class="text-subtitle1 text-weight-bold q-mb-sm">Aparência</div>
-        <div class="text-caption text-grey-7 q-mb-md">
-          Escolha como o FinanMap se apresenta para você.
-        </div>
-        
-        <q-btn-toggle
-          v-model="isDark"
-          spread
-          no-caps
-          rounded
-          unelevated
-          toggle-color="primary"
-          color="grey-3"
-          text-color="grey-9"
-          :options="[
-            { label: 'Claro', value: false, icon: 'light_mode' },
-            { label: 'Escuro', value: true, icon: 'dark_mode' }
-          ]"
-        />
-      </div>
+        <q-card-section>
+          <q-btn-toggle
+            v-model="isDark"
+            spread
+            no-caps
+            rounded
+            unelevated
+            toggle-color="primary"
+            :color="$q.dark.isActive ? 'grey-9' : 'grey-3'"
+            :text-color="$q.dark.isActive ? 'grey-4' : 'grey-8'"
+            :options="[
+              { label: 'Claro', value: false, icon: 'light_mode' },
+              { label: 'Escuro', value: true, icon: 'dark_mode' }
+            ]"
+          />
+        </q-card-section>
+      </q-card>
 
-      <q-separator class="q-my-md" />
+      <!-- Card Notificações -->
+      <q-card flat bordered class="rounded-borders-xl shadow-1">
+        <q-card-section class="q-pb-none">
+          <div class="text-subtitle1 text-weight-bold flex items-center q-gutter-x-sm">
+            <q-icon name="notifications" size="sm" color="primary" />
+            <span>Notificações</span>
+          </div>
+          <div class="text-caption text-grey-7 q-mt-xs">
+            Gerencie as preferências de notificações enviadas pelo FinanMap.
+          </div>
+        </q-card-section>
 
-      <div>
-        <div class="text-subtitle1 text-weight-bold q-mb-sm">Notificações</div>
-        <div class="text-caption text-grey-7 q-mb-md">
-          Gerencie as preferências de notificações enviadas pelo FinanMap.
-        </div>
+        <q-card-section>
+          <!-- Se estiver em modo compartilhado (como convidado) -->
+          <q-banner v-if="emModoCompartilhado" class="bg-amber-1 text-amber-9 q-mb-md" rounded dense style="border-radius: 8px;" :class="{ 'bg-grey-9 text-amber-4': $q.dark.isActive }">
+            <q-icon name="warning" class="q-mr-xs" size="18px" />
+            Você está acessando os dados compartilhados de <strong>{{ proprietarioNome }}</strong>. 
+            As preferências de notificação por e-mail estão disponíveis apenas na sua conta pessoal.
+          </q-banner>
 
-        <!-- Se estiver em modo compartilhado (como convidado) -->
-        <q-banner v-if="emModoCompartilhado" class="bg-amber-1 text-amber-9 q-mb-md rounded-borders" rounded dense style="border-radius: 8px;">
-          <q-icon name="warning" class="q-mr-xs" size="18px" />
-          Você está acessando os dados compartilhados de <strong>{{ proprietarioNome }}</strong>. 
-          As preferências de notificação por e-mail estão disponíveis apenas na sua conta pessoal.
-        </q-banner>
+          <div v-if="loadingConfig" class="q-pa-md row justify-center">
+            <q-spinner-dots color="primary" size="40px" />
+          </div>
 
-        <div v-if="loadingConfig" class="q-pa-md row justify-center">
-          <q-spinner-dots color="primary" size="40px" />
-        </div>
-
-        <q-card v-else flat bordered class="config-card q-pa-md" style="border-radius: 12px;">
-          <div class="row items-center justify-between no-wrap">
+          <div v-else class="row items-center justify-between no-wrap">
             <div class="q-pr-md">
               <div class="text-subtitle1 text-bold">Lembretes por E-mail</div>
               <div class="text-caption text-grey-6 q-mt-xs">
@@ -72,8 +83,8 @@
               @update:model-value="salvarConfiguracao"
             />
           </div>
-        </q-card>
-      </div>
+        </q-card-section>
+      </q-card>
     </div>
   </div>
 </template>
@@ -152,10 +163,15 @@ async function salvarConfiguracao(novoValor: boolean) {
 </script>
 
 <style scoped>
-.config-card {
-  transition: box-shadow 0.3s;
+.rounded-borders-xl {
+  border-radius: 16px;
 }
-.config-card:hover {
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
+
+.shadow-1 {
+  transition: box-shadow 0.3s ease, transform 0.2s ease;
+}
+
+.shadow-1:hover {
+  box-shadow: 0 6px 20px v-bind('$q.dark.isActive ? "rgba(0,0,0,0.4)" : "rgba(0,0,0,0.08)"') !important;
 }
 </style>

--- a/src/components/Configuracoes/ModalConfiguracoes.vue
+++ b/src/components/Configuracoes/ModalConfiguracoes.vue
@@ -71,8 +71,11 @@
       >
         <!-- Header Content -->
         <div
-          class="row items-center q-pa-md border-bottom"
-          :class="$q.dark.isActive ? 'border-color-dark' : 'border-color-light'"
+          class="row items-center border-bottom"
+          :class="[
+            $q.dark.isActive ? 'border-color-dark' : 'border-color-light',
+            isMobile ? 'q-pa-md' : 'q-py-sm q-px-md'
+          ]"
         >
           <q-btn
             v-if="isMobile"
@@ -85,6 +88,7 @@
             :color="$q.dark.isActive ? 'white' : 'grey-8'"
           />
           <div
+            v-if="isMobile"
             class="text-h6 text-weight-bold"
             :class="$q.dark.isActive ? 'text-white' : 'text-grey-9'"
           >

--- a/src/components/Dashbord/SectionFiltrarPeriodo.vue
+++ b/src/components/Dashbord/SectionFiltrarPeriodo.vue
@@ -3,419 +3,469 @@
     class="q-mb-md filter-section"
     :class="$q.dark.isActive ? 'filter-section--dark' : 'filter-section--light'"
   >
-    <div class="filter-inner q-pa-sm q-px-md">
-      <!-- Row with all controls in one line -->
-      <div class="filter-row">
+    <div class="filter-inner">
+      <div class="filter-header">
+        <div>
+          <div class="filter-eyebrow">
+            <q-icon name="calendar_month" size="18px" />
+            <span>Período do dashboard</span>
+          </div>
+          <div class="filter-summary">{{ periodoAplicadoFormatado }}</div>
+        </div>
 
-        <!-- Left: Title + Inputs -->
-        <div class="filter-left">
-          <!-- Title -->
-          <div class="filter-title" :class="$q.dark.isActive ? 'text-grey-4' : 'text-grey-7'">
-            <q-icon name="tune" size="16px" />
-            <span>Filtros do Período</span>
+        <q-btn
+          flat
+          no-caps
+          :icon="isEditorOpen ? 'close' : 'edit_calendar'"
+          :label="isEditorOpen ? 'Fechar' : 'Personalizar período'"
+          class="customize-btn"
+          @click="alternarEditor"
+        />
+      </div>
+
+      <div class="preset-group" aria-label="Atalhos de período">
+        <q-btn
+          v-for="preset in presets"
+          :key="preset.id"
+          unelevated
+          no-caps
+          :icon="activePreset === preset.id ? 'check' : preset.icon"
+          :label="preset.label"
+          class="preset-btn"
+          :class="{ 'preset-btn--active': activePreset === preset.id }"
+          :aria-pressed="activePreset === preset.id"
+          @click="aplicarPreset(preset.id)"
+        />
+      </div>
+
+      <q-slide-transition>
+        <div v-show="isEditorOpen" class="manual-editor">
+          <div class="period-fields">
+            <div class="period-field-group">
+              <span class="period-label">De</span>
+              <div class="period-selects">
+                <InputSelectMes
+                  v-model:model-value="localPeriodoInicial.mes"
+                  label="Mês"
+                  :styled="inputStyled"
+                  class="period-select"
+                />
+                <InputSelectAno
+                  v-model:model-value="localPeriodoInicial.ano"
+                  label="Ano"
+                  :styled="inputStyled"
+                  class="period-select period-select--ano"
+                />
+              </div>
+            </div>
+
+            <q-icon name="arrow_forward" size="20px" class="period-separator" />
+
+            <div class="period-field-group">
+              <span class="period-label">Até</span>
+              <div class="period-selects">
+                <InputSelectMes
+                  v-model:model-value="localPeriodoFinal.mes"
+                  label="Mês"
+                  :styled="inputStyled"
+                  class="period-select"
+                />
+                <InputSelectAno
+                  v-model:model-value="localPeriodoFinal.ano"
+                  label="Ano"
+                  :styled="inputStyled"
+                  class="period-select period-select--ano"
+                />
+              </div>
+            </div>
           </div>
 
-          <!-- Period inputs inline -->
-          <div class="filter-inputs-group">
-            <!-- Initial Period -->
-            <div class="filter-period-block">
-              <span class="period-label" :class="$q.dark.isActive ? 'text-grey-5' : 'text-grey-6'">
-                Período Inicial
-              </span>
-              <div class="period-selects">
-                <InputSelectMes
-                  label="Mês"
-                  v-model:model-value="localPeriodoInicial.mes"
-                  :styled="inputStyled"
-                  class="period-select"
-                />
-                <InputSelectAno
-                  label="Ano"
-                  v-model:model-value="localPeriodoInicial.ano"
-                  :styled="inputStyled"
-                  class="period-select period-select--ano"
-                />
-              </div>
-            </div>
-
-            <!-- Separator -->
-            <div class="period-separator" :class="$q.dark.isActive ? 'text-grey-6' : 'text-grey-5'">
-              <q-icon name="arrow_forward" size="18px" />
-            </div>
-
-            <!-- Final Period -->
-            <div class="filter-period-block">
-              <span class="period-label" :class="$q.dark.isActive ? 'text-grey-5' : 'text-grey-6'">
-                Período Final
-              </span>
-              <div class="period-selects">
-                <InputSelectMes
-                  label="Mês"
-                  v-model:model-value="localPeriodoFinal.mes"
-                  :styled="inputStyled"
-                  class="period-select"
-                />
-                <InputSelectAno
-                  label="Ano"
-                  v-model:model-value="localPeriodoFinal.ano"
-                  :styled="inputStyled"
-                  class="period-select period-select--ano"
-                />
-              </div>
-            </div>
-
-            <!-- Filter Button -->
+          <div class="editor-actions">
+            <q-btn flat no-caps label="Cancelar" class="cancel-btn" @click="cancelarEdicao" />
             <q-btn
               unelevated
+              no-caps
               color="primary"
-              icon="filter_list"
-              label="Filtrar"
-              class="filter-btn"
-              :class="{ 'filter-btn--error': hasValidationError }"
+              icon="check"
+              label="Aplicar período"
+              :disable="hasValidationError"
               @click="aplicarFiltroManual"
-            >
-              <q-tooltip v-if="hasValidationError" class="bg-negative">
-                {{ validationErrorMessage }}
-              </q-tooltip>
-            </q-btn>
+            />
+          </div>
+
+          <div v-if="hasValidationError" class="validation-message" role="alert">
+            <q-icon name="error_outline" size="18px" />
+            {{ validationErrorMessage }}
           </div>
         </div>
-
-        <!-- Right: Shortcuts -->
-        <div class="filter-shortcuts gt-sm">
-          <q-btn
-            v-if="showMesAtualShortcut"
-            flat
-            dense
-            no-caps
-            icon="today"
-            label="Mês Atual"
-            :color="$q.dark.isActive ? 'grey-4' : 'grey-7'"
-            class="shortcut-btn"
-            @click="aplicarMesAtual"
-          />
-          <q-btn
-            flat
-            dense
-            no-caps
-            icon="date_range"
-            label="Últimos 3 Meses"
-            :color="$q.dark.isActive ? 'grey-4' : 'grey-7'"
-            class="shortcut-btn"
-            @click="aplicarUltimosTresMeses"
-          />
-          <q-btn
-            flat
-            dense
-            no-caps
-            icon="calendar_today"
-            label="Este Ano"
-            :color="$q.dark.isActive ? 'grey-4' : 'grey-7'"
-            class="shortcut-btn"
-            @click="aplicarEsteAno"
-          />
-        </div>
-      </div>
-
-      <!-- Mobile shortcuts -->
-      <div class="lt-md q-mt-sm">
-        <div class="row q-gutter-xs justify-center">
-          <q-chip
-            v-if="showMesAtualShortcut"
-            clickable
-            @click="aplicarMesAtual"
-            :color="$q.dark.isActive ? 'grey-9' : 'primary'"
-            text-color="white"
-            :outline="!$q.dark.isActive"
-            icon="today"
-            dense
-          >
-            Mês Atual
-          </q-chip>
-          <q-chip
-            clickable
-            @click="aplicarUltimosTresMeses"
-            :color="$q.dark.isActive ? 'grey-9' : 'primary'"
-            text-color="white"
-            :outline="!$q.dark.isActive"
-            icon="date_range"
-            dense
-          >
-            Últimos 3 Meses
-          </q-chip>
-          <q-chip
-            clickable
-            @click="aplicarEsteAno"
-            :color="$q.dark.isActive ? 'grey-9' : 'primary'"
-            text-color="white"
-            :outline="!$q.dark.isActive"
-            icon="calendar_today"
-            dense
-          >
-            Este Ano
-          </q-chip>
-        </div>
-      </div>
+      </q-slide-transition>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, watch, computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useDashboardStore } from 'src/stores/dashboardStore';
 import InputSelectAno from 'src/components/Inputs/InputSelectAno.vue';
 import InputSelectMes from 'src/components/Inputs/InputSelectMes.vue';
 import { useQuasar } from 'quasar';
 
+type Periodo = { mes: number; ano: number };
+type PresetId = 'mes-atual' | 'ultimos-tres-meses' | 'este-ano';
+
 const $q = useQuasar();
 const dashboardStore = useDashboardStore();
 
 const inputStyled = { dense: true, filled: false, rounded: false, borderless: false };
+const isEditorOpen = ref(false);
 
-// Local state for inputs to allow manual filtering
-const localPeriodoInicial = ref<{ mes: number; ano: number }>({
+const localPeriodoInicial = ref<Periodo>({
   mes: dashboardStore.mesInicial,
   ano: dashboardStore.anoInicial,
 });
-const localPeriodoFinal = ref<{ mes: number; ano: number }>({
+const localPeriodoFinal = ref<Periodo>({
   mes: dashboardStore.mesFinal,
   ano: dashboardStore.anoFinal,
 });
 
-// Validation
+const presets: Array<{ id: PresetId; label: string; icon: string }> = [
+  { id: 'mes-atual', label: 'Mês atual', icon: 'today' },
+  { id: 'ultimos-tres-meses', label: 'Últimos 3 meses', icon: 'date_range' },
+  { id: 'este-ano', label: 'Este ano', icon: 'calendar_today' },
+];
+
+const periodoAplicadoInicial = computed<Periodo>(() => ({
+  mes: dashboardStore.mesInicial,
+  ano: dashboardStore.anoInicial,
+}));
+
+const periodoAplicadoFinal = computed<Periodo>(() => ({
+  mes: dashboardStore.mesFinal,
+  ano: dashboardStore.anoFinal,
+}));
+
 const hasValidationError = computed(() => {
   const pIni = localPeriodoInicial.value.ano * 100 + localPeriodoInicial.value.mes;
   const pFim = localPeriodoFinal.value.ano * 100 + localPeriodoFinal.value.mes;
   return pIni > pFim;
 });
 
-const validationErrorMessage = computed(() => {
-  return hasValidationError.value ? 'O período inicial não pode ser posterior ao final' : '';
+const validationErrorMessage = computed(() =>
+  hasValidationError.value ? 'O período inicial não pode ser posterior ao período final.' : ''
+);
+
+const activePreset = computed<PresetId | null>(() => {
+  const inicio = periodoAplicadoInicial.value;
+  const fim = periodoAplicadoFinal.value;
+
+  for (const preset of presets) {
+    const periodoPreset = obterPeriodoPreset(preset.id);
+    if (periodosIguais(inicio, periodoPreset.inicio) && periodosIguais(fim, periodoPreset.fim)) {
+      return preset.id;
+    }
+  }
+
+  return null;
 });
 
-// Show "Mês Atual" shortcut only when not already viewing current month
-const showMesAtualShortcut = computed(() => {
-  const dataAtual = new Date();
-  const mesAtual = dataAtual.getMonth() + 1;
-  const anoAtual = dataAtual.getFullYear();
+const periodoAplicadoFormatado = computed(() => {
+  const inicio = periodoAplicadoInicial.value;
+  const fim = periodoAplicadoFinal.value;
+  const inicioFormatado = formatarMesAno(inicio);
 
-  return !(localPeriodoInicial.value.mes === mesAtual &&
-           localPeriodoInicial.value.ano === anoAtual &&
-           localPeriodoFinal.value.mes === mesAtual &&
-           localPeriodoFinal.value.ano === anoAtual);
+  if (periodosIguais(inicio, fim)) {
+    return capitalizar(inicioFormatado);
+  }
+
+  if (inicio.ano === fim.ano) {
+    const mesInicial = formatarMes(inicio);
+    return `${capitalizar(mesInicial)} a ${capitalizar(formatarMesAno(fim))}`;
+  }
+
+  return `${capitalizar(inicioFormatado)} a ${capitalizar(formatarMesAno(fim))}`;
 });
 
-// Sync local state when store changes
-watch(() => dashboardStore.mesInicial, (val) => localPeriodoInicial.value.mes = val);
-watch(() => dashboardStore.anoInicial, (val) => localPeriodoInicial.value.ano = val);
-watch(() => dashboardStore.mesFinal, (val) => localPeriodoFinal.value.mes = val);
-watch(() => dashboardStore.anoFinal, (val) => localPeriodoFinal.value.ano = val);
+watch(
+  () => [
+    dashboardStore.mesInicial,
+    dashboardStore.anoInicial,
+    dashboardStore.mesFinal,
+    dashboardStore.anoFinal,
+  ],
+  () => restaurarRascunho()
+);
 
-const aplicarFiltroManual = () => {
-  if (hasValidationError.value) {
-    $q.notify({
-      type: 'negative',
-      message: 'O período inicial não pode ser maior que o período final',
-      position: 'top',
-      timeout: 3000,
-      icon: 'warning'
-    });
+function periodosIguais(periodoA: Periodo, periodoB: Periodo) {
+  return periodoA.mes === periodoB.mes && periodoA.ano === periodoB.ano;
+}
+
+function dataDoPeriodo(periodo: Periodo) {
+  return new Date(periodo.ano, periodo.mes - 1, 1);
+}
+
+function formatarMes(periodo: Periodo) {
+  return new Intl.DateTimeFormat('pt-BR', { month: 'long' }).format(dataDoPeriodo(periodo));
+}
+
+function formatarMesAno(periodo: Periodo) {
+  return new Intl.DateTimeFormat('pt-BR', { month: 'long', year: 'numeric' }).format(
+    dataDoPeriodo(periodo)
+  );
+}
+
+function capitalizar(valor: string) {
+  return valor.charAt(0).toLocaleUpperCase('pt-BR') + valor.slice(1);
+}
+
+function obterPeriodoPreset(preset: PresetId): { inicio: Periodo; fim: Periodo } {
+  const atual = new Date();
+  const fim = { mes: atual.getMonth() + 1, ano: atual.getFullYear() };
+
+  if (preset === 'mes-atual') {
+    return { inicio: { ...fim }, fim };
+  }
+
+  if (preset === 'este-ano') {
+    return { inicio: { mes: 1, ano: atual.getFullYear() }, fim };
+  }
+
+  const inicio = new Date(atual.getFullYear(), atual.getMonth() - 2, 1);
+  return {
+    inicio: { mes: inicio.getMonth() + 1, ano: inicio.getFullYear() },
+    fim,
+  };
+}
+
+function restaurarRascunho() {
+  localPeriodoInicial.value = { ...periodoAplicadoInicial.value };
+  localPeriodoFinal.value = { ...periodoAplicadoFinal.value };
+}
+
+function alternarEditor() {
+  if (isEditorOpen.value) {
+    cancelarEdicao();
     return;
   }
 
-  dashboardStore.setFiltros(
-    localPeriodoInicial.value.mes,
-    localPeriodoInicial.value.ano,
-    localPeriodoFinal.value.mes,
-    localPeriodoFinal.value.ano
-  );
+  restaurarRascunho();
+  isEditorOpen.value = true;
+}
 
-  $q.notify({
-    type: 'positive',
-    message: 'Filtros aplicados com sucesso',
-    position: 'top',
-    timeout: 2000,
-    icon: 'check_circle'
-  });
-};
+function cancelarEdicao() {
+  restaurarRascunho();
+  isEditorOpen.value = false;
+}
 
-const aplicarMesAtual = () => {
-  const dataAtual = new Date();
-  const mesAtual = dataAtual.getMonth() + 1;
-  const anoAtual = dataAtual.getFullYear();
+function aplicarPeriodo(inicio: Periodo, fim: Periodo) {
+  dashboardStore.setFiltros(inicio.mes, inicio.ano, fim.mes, fim.ano);
+}
 
-  localPeriodoInicial.value = { mes: mesAtual, ano: anoAtual };
-  localPeriodoFinal.value = { mes: mesAtual, ano: anoAtual };
+function aplicarPreset(preset: PresetId) {
+  const periodo = obterPeriodoPreset(preset);
+  aplicarPeriodo(periodo.inicio, periodo.fim);
+}
 
-  aplicarFiltroManual();
-};
+function aplicarFiltroManual() {
+  if (hasValidationError.value) return;
 
-const aplicarUltimosTresMeses = () => {
-  const dataAtual = new Date();
-  const mesAtual = dataAtual.getMonth() + 1;
-  const anoAtual = dataAtual.getFullYear();
-
-  localPeriodoFinal.value = { mes: mesAtual, ano: anoAtual };
-
-  let mesIni = mesAtual - 2;
-  let anoIni = anoAtual;
-
-  if (mesIni <= 0) {
-    mesIni += 12;
-    anoIni -= 1;
-  }
-
-  localPeriodoInicial.value = { mes: mesIni, ano: anoIni };
-
-  aplicarFiltroManual();
-};
-
-const aplicarEsteAno = () => {
-  const dataAtual = new Date();
-  const anoAtual = dataAtual.getFullYear();
-
-  localPeriodoInicial.value = { mes: 1, ano: anoAtual };
-  localPeriodoFinal.value = { mes: dataAtual.getMonth() + 1, ano: anoAtual };
-
-  aplicarFiltroManual();
-};
-
-onMounted(() => {
-  aplicarFiltroManual();
-});
+  aplicarPeriodo(localPeriodoInicial.value, localPeriodoFinal.value);
+  isEditorOpen.value = false;
+}
 </script>
 
 <style scoped>
-/* Section wrapper */
 .filter-section {
-  border-radius: 12px;
+  border-radius: 16px;
   overflow: hidden;
 }
 
 .filter-section--light {
   background: #ffffff;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07);
-  border: 1px solid rgba(0, 0, 0, 0.08);
+  border: 1px solid rgba(45, 55, 72, 0.1);
+  box-shadow: 0 8px 24px rgba(45, 55, 72, 0.06);
 }
 
 .filter-section--dark {
-  background: #1d1d1d;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.35);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: #1d1e22;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
 }
 
-/* Main row: left inputs + right shortcuts */
-.filter-row {
+.filter-inner {
+  padding: 18px 20px;
+}
+
+.filter-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.filter-eyebrow {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 7px;
+  color: #77808f;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.filter-section--dark .filter-eyebrow {
+  color: #a7afbd;
+}
+
+.filter-summary {
+  margin-top: 3px;
+  color: #263248;
+  font-size: clamp(20px, 2.2vw, 28px);
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+}
+
+.filter-section--dark .filter-summary {
+  color: #f1f3f7;
+}
+
+.customize-btn {
+  color: var(--q-primary);
+  border-radius: 9px;
+  font-weight: 600;
+}
+
+.preset-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.preset-btn {
+  min-height: 38px;
+  padding: 0 14px;
+  color: #5e6878;
+  background: rgba(96, 107, 125, 0.08);
+  border: 1px solid transparent;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.filter-section--dark .preset-btn {
+  color: #c2c8d2;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.preset-btn--active {
+  color: var(--q-primary);
+  background: rgba(63, 81, 181, 0.1);
+  border-color: rgba(63, 81, 181, 0.28);
+}
+
+.filter-section--dark .preset-btn--active {
+  color: #aeb9ff;
+  background: rgba(120, 136, 255, 0.13);
+  border-color: rgba(151, 163, 255, 0.34);
+}
+
+.manual-editor {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 14px 20px;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(96, 107, 125, 0.15);
+}
+
+.filter-section--dark .manual-editor {
+  border-top-color: rgba(255, 255, 255, 0.09);
+}
+
+.period-fields,
+.period-selects,
+.editor-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.period-fields {
   gap: 12px;
   flex-wrap: wrap;
 }
 
-/* Left: title + inputs inline */
-.filter-left {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  flex-wrap: wrap;
-}
-
-.filter-title {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 13px;
-  font-weight: 600;
-  white-space: nowrap;
-  letter-spacing: 0.01em;
-}
-
-/* Group of period selectors + button */
-.filter-inputs-group {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-
-/* Individual period block (label + selects) */
-.filter-period-block {
+.period-field-group {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 5px;
 }
 
 .period-label {
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.02em;
-  padding-left: 2px;
-  opacity: 0.8;
+  color: #6d7685;
+  font-size: 12px;
+  font-weight: 700;
 }
 
-.period-selects {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+.filter-section--dark .period-label {
+  color: #adb4c0;
 }
 
-/* Individual select fields */
 .period-select {
-  width: 130px;
+  width: 140px;
 }
 
 .period-select--ano {
-  width: 90px;
+  width: 96px;
 }
 
-/* Arrow separator between periods */
 .period-separator {
-  display: flex;
-  align-items: flex-end;
-  padding-bottom: 6px;
-  opacity: 0.5;
+  margin-top: 20px;
+  color: #8b94a3;
 }
 
-/* Filter button */
-.filter-btn {
-  height: 40px;
-  padding: 0 20px;
-  border-radius: 8px;
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  margin-top: 14px;
-  transition: all 0.2s ease;
+.editor-actions {
+  align-self: end;
+  justify-self: end;
 }
 
-.filter-btn--error {
-  background-color: var(--q-negative) !important;
+.cancel-btn {
+  color: #657083;
 }
 
-.filter-btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(63, 81, 181, 0.35);
-}
-
-/* Right shortcuts */
-.filter-shortcuts {
+.validation-message {
+  grid-column: 1 / -1;
   display: flex;
   align-items: center;
-  gap: 2px;
-  flex-shrink: 0;
+  gap: 6px;
+  color: var(--q-negative);
+  font-size: 13px;
+  font-weight: 600;
 }
 
-.shortcut-btn {
-  border-radius: 8px;
-  font-size: 12px;
-  font-weight: 500;
-  padding: 4px 10px;
-  transition: all 0.18s ease;
-  opacity: 0.75;
-}
+@media (max-width: 700px) {
+  .filter-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
 
-.shortcut-btn:hover {
-  opacity: 1;
-  background: rgba(0, 0, 0, 0.06);
+  .customize-btn {
+    align-self: flex-start;
+  }
+
+  .manual-editor {
+    grid-template-columns: 1fr;
+  }
+
+  .period-separator {
+    display: none;
+  }
+
+  .editor-actions {
+    justify-self: stretch;
+  }
 }
 </style>

--- a/src/components/Dashbord/SectionFiltrarPeriodo.vue
+++ b/src/components/Dashbord/SectionFiltrarPeriodo.vue
@@ -6,12 +6,27 @@
   >
     <div class="filter-inner">
       <div class="filter-header">
-        <div>
+        <div class="filter-period">
           <div id="dashboard-period-title" class="filter-eyebrow">
             <q-icon name="calendar_month" size="18px" />
             <span>Período do dashboard</span>
           </div>
           <div class="filter-summary" aria-live="polite">{{ periodoAplicadoFormatado }}</div>
+        </div>
+
+        <div class="preset-group" aria-label="Atalhos de período">
+          <q-btn
+            v-for="preset in presets"
+            :key="preset.id"
+            unelevated
+            no-caps
+            :icon="activePreset === preset.id ? 'check' : preset.icon"
+            :label="preset.label"
+            class="preset-btn"
+            :class="{ 'preset-btn--active': activePreset === preset.id }"
+            :aria-pressed="activePreset === preset.id"
+            @click="aplicarPreset(preset.id)"
+          />
         </div>
 
         <q-btn
@@ -23,21 +38,6 @@
           :aria-expanded="isEditorOpen"
           aria-controls="dashboard-period-editor"
           @click="alternarEditor"
-        />
-      </div>
-
-      <div class="preset-group" aria-label="Atalhos de período">
-        <q-btn
-          v-for="preset in presets"
-          :key="preset.id"
-          unelevated
-          no-caps
-          :icon="activePreset === preset.id ? 'check' : preset.icon"
-          :label="preset.label"
-          class="preset-btn"
-          :class="{ 'preset-btn--active': activePreset === preset.id }"
-          :aria-pressed="activePreset === preset.id"
-          @click="aplicarPreset(preset.id)"
         />
       </div>
 
@@ -57,7 +57,7 @@
                   label="Mês"
                   aria-label="Mês inicial"
                   :styled="inputStyled"
-                  class="period-select"
+                  class="period-select period-select--mes"
                 />
                 <InputSelectAno
                   v-model:model-value="localPeriodoInicial.ano"
@@ -79,7 +79,7 @@
                   label="Mês"
                   aria-label="Mês final"
                   :styled="inputStyled"
-                  class="period-select"
+                  class="period-select period-select--mes"
                 />
                 <InputSelectAno
                   v-model:model-value="localPeriodoFinal.ano"
@@ -171,7 +171,7 @@ const hasValidationError = computed(() => {
 });
 
 const validationErrorMessage = computed(() =>
-  hasValidationError.value ? 'O período inicial não pode ser posterior ao período final.' : ''
+  hasValidationError.value ? 'O período inicial não pode ser posterior ao período final.' : '',
 );
 
 const activePreset = computed<PresetId | null>(() => {
@@ -212,7 +212,7 @@ watch(
     dashboardStore.mesFinal,
     dashboardStore.anoFinal,
   ],
-  () => restaurarRascunho()
+  () => restaurarRascunho(),
 );
 
 onMounted(() => {
@@ -243,7 +243,7 @@ function formatarMes(periodo: Periodo) {
 
 function formatarMesAno(periodo: Periodo) {
   return new Intl.DateTimeFormat('pt-BR', { month: 'long', year: 'numeric' }).format(
-    dataDoPeriodo(periodo)
+    dataDoPeriodo(periodo),
   );
 }
 
@@ -330,10 +330,14 @@ function aplicarFiltroManual() {
 }
 
 .filter-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(190px, 1fr) auto minmax(190px, 1fr);
+  align-items: center;
   gap: 16px;
+}
+
+.filter-period {
+  min-width: 0;
 }
 
 .filter-eyebrow {
@@ -354,7 +358,7 @@ function aplicarFiltroManual() {
 .filter-summary {
   margin-top: 3px;
   color: #263248;
-  font-size: clamp(20px, 2.2vw, 28px);
+  font-size: clamp(17px, 1.8vw, 22px);
   font-weight: 700;
   letter-spacing: -0.025em;
   line-height: 1.2;
@@ -365,6 +369,7 @@ function aplicarFiltroManual() {
 }
 
 .customize-btn {
+  justify-self: end;
   min-height: 44px;
   color: var(--q-primary);
   border-radius: 9px;
@@ -378,9 +383,9 @@ function aplicarFiltroManual() {
 .preset-group {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
   flex-wrap: wrap;
-  margin-top: 16px;
 }
 
 .preset-btn {
@@ -463,6 +468,10 @@ function aplicarFiltroManual() {
   width: 140px;
 }
 
+.period-select--mes :deep(.q-field__native) {
+  font-size: 13px;
+}
+
 .period-select--ano {
   width: 96px;
 }
@@ -523,17 +532,46 @@ function aplicarFiltroManual() {
   font-weight: 600;
 }
 
+@media (max-width: 1100px) {
+  .filter-header {
+    grid-template-areas:
+      'period presets'
+      'customize customize';
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .filter-period {
+    grid-area: period;
+  }
+
+  .preset-group {
+    grid-area: presets;
+  }
+
+  .customize-btn {
+    grid-area: customize;
+  }
+}
+
 @media (max-width: 700px) {
   .filter-inner {
     padding: 16px;
   }
 
   .filter-header {
-    align-items: stretch;
-    flex-direction: column;
+    grid-template-areas:
+      'period'
+      'presets'
+      'customize';
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .preset-group {
+    justify-content: flex-start;
   }
 
   .customize-btn {
+    justify-self: stretch;
     align-self: stretch;
   }
 

--- a/src/components/Dashbord/SectionFiltrarPeriodo.vue
+++ b/src/components/Dashbord/SectionFiltrarPeriodo.vue
@@ -2,15 +2,16 @@
   <section
     class="q-mb-md filter-section"
     :class="$q.dark.isActive ? 'filter-section--dark' : 'filter-section--light'"
+    aria-labelledby="dashboard-period-title"
   >
     <div class="filter-inner">
       <div class="filter-header">
         <div>
-          <div class="filter-eyebrow">
+          <div id="dashboard-period-title" class="filter-eyebrow">
             <q-icon name="calendar_month" size="18px" />
             <span>Período do dashboard</span>
           </div>
-          <div class="filter-summary">{{ periodoAplicadoFormatado }}</div>
+          <div class="filter-summary" aria-live="polite">{{ periodoAplicadoFormatado }}</div>
         </div>
 
         <q-btn
@@ -19,6 +20,8 @@
           :icon="isEditorOpen ? 'close' : 'edit_calendar'"
           :label="isEditorOpen ? 'Fechar' : 'Personalizar período'"
           class="customize-btn"
+          :aria-expanded="isEditorOpen"
+          aria-controls="dashboard-period-editor"
           @click="alternarEditor"
         />
       </div>
@@ -38,8 +41,13 @@
         />
       </div>
 
-      <q-slide-transition>
-        <div v-show="isEditorOpen" class="manual-editor">
+      <q-slide-transition :duration="prefersReducedMotion ? 0 : 300">
+        <div
+          id="dashboard-period-editor"
+          v-show="isEditorOpen"
+          class="manual-editor"
+          v-bind="hasValidationError ? { 'aria-describedby': 'dashboard-period-error' } : {}"
+        >
           <div class="period-fields">
             <div class="period-field-group">
               <span class="period-label">De</span>
@@ -47,12 +55,14 @@
                 <InputSelectMes
                   v-model:model-value="localPeriodoInicial.mes"
                   label="Mês"
+                  aria-label="Mês inicial"
                   :styled="inputStyled"
                   class="period-select"
                 />
                 <InputSelectAno
                   v-model:model-value="localPeriodoInicial.ano"
                   label="Ano"
+                  aria-label="Ano inicial"
                   :styled="inputStyled"
                   class="period-select period-select--ano"
                 />
@@ -67,12 +77,14 @@
                 <InputSelectMes
                   v-model:model-value="localPeriodoFinal.mes"
                   label="Mês"
+                  aria-label="Mês final"
                   :styled="inputStyled"
                   class="period-select"
                 />
                 <InputSelectAno
                   v-model:model-value="localPeriodoFinal.ano"
                   label="Ano"
+                  aria-label="Ano final"
                   :styled="inputStyled"
                   class="period-select period-select--ano"
                 />
@@ -93,7 +105,13 @@
             />
           </div>
 
-          <div v-if="hasValidationError" class="validation-message" role="alert">
+          <div
+            v-if="hasValidationError"
+            id="dashboard-period-error"
+            class="validation-message"
+            role="status"
+            aria-live="polite"
+          >
             <q-icon name="error_outline" size="18px" />
             {{ validationErrorMessage }}
           </div>
@@ -104,7 +122,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { useDashboardStore } from 'src/stores/dashboardStore';
 import InputSelectAno from 'src/components/Inputs/InputSelectAno.vue';
 import InputSelectMes from 'src/components/Inputs/InputSelectMes.vue';
@@ -118,6 +136,8 @@ const dashboardStore = useDashboardStore();
 
 const inputStyled = { dense: true, filled: false, rounded: false, borderless: false };
 const isEditorOpen = ref(false);
+const prefersReducedMotion = ref(false);
+let reducedMotionMediaQuery: MediaQueryList | undefined;
 
 const localPeriodoInicial = ref<Periodo>({
   mes: dashboardStore.mesInicial,
@@ -194,6 +214,20 @@ watch(
   ],
   () => restaurarRascunho()
 );
+
+onMounted(() => {
+  reducedMotionMediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+  prefersReducedMotion.value = reducedMotionMediaQuery.matches;
+  reducedMotionMediaQuery.addEventListener('change', atualizarPreferenciaDeMovimento);
+});
+
+onBeforeUnmount(() => {
+  reducedMotionMediaQuery?.removeEventListener('change', atualizarPreferenciaDeMovimento);
+});
+
+function atualizarPreferenciaDeMovimento(event: MediaQueryListEvent) {
+  prefersReducedMotion.value = event.matches;
+}
 
 function periodosIguais(periodoA: Periodo, periodoB: Periodo) {
   return periodoA.mes === periodoB.mes && periodoA.ano === periodoB.ano;
@@ -331,9 +365,14 @@ function aplicarFiltroManual() {
 }
 
 .customize-btn {
+  min-height: 44px;
   color: var(--q-primary);
   border-radius: 9px;
   font-weight: 600;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease,
+    box-shadow 160ms ease;
 }
 
 .preset-group {
@@ -345,7 +384,7 @@ function aplicarFiltroManual() {
 }
 
 .preset-btn {
-  min-height: 38px;
+  min-height: 44px;
   padding: 0 14px;
   color: #5e6878;
   background: rgba(96, 107, 125, 0.08);
@@ -353,6 +392,11 @@ function aplicarFiltroManual() {
   border-radius: 10px;
   font-size: 13px;
   font-weight: 600;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    box-shadow 160ms ease;
 }
 
 .filter-section--dark .preset-btn {
@@ -415,6 +459,7 @@ function aplicarFiltroManual() {
 }
 
 .period-select {
+  min-width: 0;
   width: 140px;
 }
 
@@ -432,8 +477,40 @@ function aplicarFiltroManual() {
   justify-self: end;
 }
 
+.editor-actions :deep(.q-btn) {
+  min-height: 44px;
+}
+
 .cancel-btn {
   color: #657083;
+}
+
+.filter-section--dark .cancel-btn {
+  color: #c1c7d0;
+}
+
+.customize-btn:focus-visible,
+.preset-btn:focus-visible,
+.editor-actions :deep(.q-btn:focus-visible),
+.period-select :deep(.q-field__native:focus-visible) {
+  outline: 3px solid rgba(63, 81, 181, 0.42);
+  outline-offset: 3px;
+}
+
+.filter-section--dark .customize-btn:focus-visible,
+.filter-section--dark .preset-btn:focus-visible,
+.filter-section--dark .editor-actions :deep(.q-btn:focus-visible),
+.filter-section--dark .period-select :deep(.q-field__native:focus-visible) {
+  outline-color: rgba(174, 185, 255, 0.72);
+}
+
+.customize-btn:hover,
+.preset-btn:hover {
+  background-color: rgba(63, 81, 181, 0.12);
+}
+
+.preset-btn:active {
+  background-color: rgba(63, 81, 181, 0.18);
 }
 
 .validation-message {
@@ -447,17 +524,41 @@ function aplicarFiltroManual() {
 }
 
 @media (max-width: 700px) {
+  .filter-inner {
+    padding: 16px;
+  }
+
   .filter-header {
     align-items: stretch;
     flex-direction: column;
   }
 
   .customize-btn {
-    align-self: flex-start;
+    align-self: stretch;
   }
 
   .manual-editor {
     grid-template-columns: 1fr;
+  }
+
+  .period-fields,
+  .period-field-group,
+  .period-selects {
+    width: 100%;
+  }
+
+  .period-field-group {
+    min-width: 0;
+  }
+
+  .period-select {
+    flex: 1 1 0;
+    width: auto;
+  }
+
+  .period-select--ano {
+    flex: 0 1 110px;
+    width: auto;
   }
 
   .period-separator {
@@ -465,7 +566,35 @@ function aplicarFiltroManual() {
   }
 
   .editor-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
     justify-self: stretch;
+  }
+}
+
+@media (max-width: 380px) {
+  .filter-inner {
+    padding: 14px 12px;
+  }
+
+  .preset-group,
+  .editor-actions,
+  .period-selects {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .preset-btn,
+  .period-select,
+  .period-select--ano {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .customize-btn,
+  .preset-btn {
+    transition-duration: 0.01ms;
   }
 }
 </style>

--- a/src/components/Transacao/TransacaoBaseModal.vue
+++ b/src/components/Transacao/TransacaoBaseModal.vue
@@ -29,8 +29,9 @@
               v-if="props.tipoCategoriaTransacao === TipoCategoriaETransacao.Investimento && compartilhamentoStore.podeEditar"
               class="q-mt-sm">
               <q-select v-model="(dadosFormulario as any).metaFinanceiraId" :options="metasDisponiveis"
-                option-label="nome" option-value="id" outlined rounded dense label="Vincular a uma Meta (opcional)"
-                clearable emit-value map-options :loading="loadingMetas">
+                option-label="nome" option-value="id" filled rounded label="Vincular a uma Meta (opcional)"
+                clearable emit-value map-options :loading="loadingMetas" options-cover transition-show="scale"
+                transition-hide="scale" behavior="menu">
                 <template v-slot:option="{ opt, itemProps }">
                   <q-item v-bind="itemProps">
                     <q-item-section avatar>

--- a/src/helpers/DashboardPeriodQuery.ts
+++ b/src/helpers/DashboardPeriodQuery.ts
@@ -1,0 +1,55 @@
+import type { LocationQueryValue } from 'vue-router';
+
+export type DashboardPeriod = {
+  mes: number;
+  ano: number;
+};
+
+export type DashboardPeriodRange = {
+  inicio: DashboardPeriod;
+  fim: DashboardPeriod;
+};
+
+type DashboardPeriodQueryValue = LocationQueryValue | LocationQueryValue[] | undefined;
+
+function parsePeriod(value: DashboardPeriodQueryValue): DashboardPeriod | null {
+  if (typeof value !== 'string') return null;
+
+  const match = /^(\d{4})-(\d{2})$/.exec(value);
+  if (!match) return null;
+
+  const ano = Number(match[1]);
+  const mes = Number(match[2]);
+
+  if (ano < 1 || mes < 1 || mes > 12) return null;
+
+  return { mes, ano };
+}
+
+function periodValue(period: DashboardPeriod) {
+  return period.ano * 100 + period.mes;
+}
+
+export function currentDashboardPeriod(date = new Date()): DashboardPeriodRange {
+  const current = { mes: date.getMonth() + 1, ano: date.getFullYear() };
+  return { inicio: { ...current }, fim: current };
+}
+
+export function parseDashboardPeriodQuery(
+  inicio: DashboardPeriodQueryValue,
+  fim: DashboardPeriodQueryValue,
+  fallback = currentDashboardPeriod(),
+): DashboardPeriodRange {
+  const parsedInicio = parsePeriod(inicio);
+  const parsedFim = parsePeriod(fim);
+
+  if (!parsedInicio || !parsedFim || periodValue(parsedInicio) > periodValue(parsedFim)) {
+    return fallback;
+  }
+
+  return { inicio: parsedInicio, fim: parsedFim };
+}
+
+export function formatDashboardPeriodQuery(period: DashboardPeriod) {
+  return `${period.ano}-${String(period.mes).padStart(2, '0')}`;
+}

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -13,12 +13,19 @@
         <q-space />
 
         <!-- Seletor de Contexto de Compartilhamento -->
-        <ContextoSelector v-if="$q.screen.gt.sm" class="q-mr-md" />
+        <ContextoSelector class="contexto-selector-header q-mr-md" />
 
-        <DateDisplay />
+        <DateDisplay v-if="$q.screen.gt.xs" />
 
         <div class="q-gutter-sm row items-center no-wrap">
-          <q-btn round dense flat color="grey-4" @click="themeStore.toggleTheme()">
+          <q-btn
+            v-if="$q.screen.gt.xs"
+            round
+            dense
+            flat
+            color="grey-4"
+            @click="themeStore.toggleTheme()"
+          >
             <q-icon :name="themeStore.isDark ? 'light_mode' : 'dark_mode'" size="25px" />
             <q-tooltip>{{ themeStore.isDark ? 'Modo Claro' : 'Modo Escuro' }}</q-tooltip>
           </q-btn>
@@ -50,6 +57,17 @@
                 </q-item>
 
                 <q-separator />
+
+                <q-item v-if="$q.screen.xs" clickable v-ripple @click="themeStore.toggleTheme()">
+                  <q-item-section avatar>
+                    <q-icon :name="themeStore.isDark ? 'light_mode' : 'dark_mode'" />
+                  </q-item-section>
+                  <q-item-section>
+                    <q-item-label>
+                      {{ themeStore.isDark ? 'Modo Claro' : 'Modo Escuro' }}
+                    </q-item-label>
+                  </q-item-section>
+                </q-item>
 
                 <!-- Botão de logout -->
                 <q-item clickable v-ripple @click="handleLogout">
@@ -199,6 +217,12 @@ defineOptions({
   font-weight: 600;
   font-size: 1.1rem;
   color: #646464;
+}
+
+@media (max-width: 599px) {
+  .contexto-selector-header {
+    margin-right: 4px;
+  }
 }
 </style>
 <style lang="sass" scoped>

--- a/src/pages/Dashbord/dashbord-Gerenciamento-Mensal.vue
+++ b/src/pages/Dashbord/dashbord-Gerenciamento-Mensal.vue
@@ -15,7 +15,6 @@
 
   <q-page padding :class="$q.dark.isActive ? 'bg-dark-page' : 'bg-grey-2'">
     <div class="content-limit">
-
       <!-- Filter Section -->
       <div class="dashboard-section dashboard-section--delay-0">
         <SectionFiltrarPeriodo />
@@ -66,12 +65,13 @@
           <DashboardPeriodChart />
         </div>
       </div>
-
     </div>
   </q-page>
 </template>
 
 <script setup lang="ts">
+import { watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 import SectionFiltrarPeriodo from 'src/components/Dashbord/SectionFiltrarPeriodo.vue';
 import BannerModoCompartilhado from 'src/components/Compartilhamento/BannerModoCompartilhado.vue';
 import DashboardSummaryCards from 'src/components/Dashbord/DashboardSummaryCards.vue';
@@ -83,6 +83,76 @@ import DashboardBalanceCard from 'src/components/Dashbord/DashboardBalanceCard.v
 import DashboardTrendLineChart from 'src/components/Dashbord/DashboardTrendLineChart.vue';
 import DashboardCategoryTreemap from 'src/components/Dashbord/DashboardCategoryTreemap.vue';
 import DashboardRadialComposition from 'src/components/Dashbord/DashboardRadialComposition.vue';
+import { useDashboardStore } from 'src/stores/dashboardStore';
+import {
+  formatDashboardPeriodQuery,
+  parseDashboardPeriodQuery,
+  type DashboardPeriodRange,
+} from 'src/helpers/DashboardPeriodQuery';
+
+const route = useRoute();
+const router = useRouter();
+const dashboardStore = useDashboardStore();
+
+function storeMatchesPeriod(period: DashboardPeriodRange) {
+  return (
+    dashboardStore.mesInicial === period.inicio.mes &&
+    dashboardStore.anoInicial === period.inicio.ano &&
+    dashboardStore.mesFinal === period.fim.mes &&
+    dashboardStore.anoFinal === period.fim.ano
+  );
+}
+
+function syncRouteWithStore() {
+  const inicio = formatDashboardPeriodQuery({
+    mes: dashboardStore.mesInicial,
+    ano: dashboardStore.anoInicial,
+  });
+  const fim = formatDashboardPeriodQuery({
+    mes: dashboardStore.mesFinal,
+    ano: dashboardStore.anoFinal,
+  });
+
+  if (route.query.inicio === inicio && route.query.fim === fim) return;
+
+  void router.replace({
+    query: {
+      ...route.query,
+      inicio,
+      fim,
+    },
+  });
+}
+
+watch(
+  () => [route.query.inicio, route.query.fim],
+  ([inicio, fim]) => {
+    const period = parseDashboardPeriodQuery(inicio, fim);
+
+    if (!storeMatchesPeriod(period)) {
+      dashboardStore.setFiltros(
+        period.inicio.mes,
+        period.inicio.ano,
+        period.fim.mes,
+        period.fim.ano,
+      );
+      return;
+    }
+
+    syncRouteWithStore();
+  },
+  { immediate: true },
+);
+
+watch(
+  () => [
+    dashboardStore.mesInicial,
+    dashboardStore.anoInicial,
+    dashboardStore.mesFinal,
+    dashboardStore.anoFinal,
+  ],
+  syncRouteWithStore,
+);
 </script>
 
 <style scoped>
@@ -103,12 +173,24 @@ import DashboardRadialComposition from 'src/components/Dashbord/DashboardRadialC
   transform: translateY(16px);
 }
 
-.dashboard-section--delay-0 { animation-delay: 0ms; }
-.dashboard-section--delay-1 { animation-delay: 80ms; }
-.dashboard-section--delay-2 { animation-delay: 160ms; }
-.dashboard-section--delay-3 { animation-delay: 240ms; }
-.dashboard-section--delay-4 { animation-delay: 320ms; }
-.dashboard-section--delay-5 { animation-delay: 400ms; }
+.dashboard-section--delay-0 {
+  animation-delay: 0ms;
+}
+.dashboard-section--delay-1 {
+  animation-delay: 80ms;
+}
+.dashboard-section--delay-2 {
+  animation-delay: 160ms;
+}
+.dashboard-section--delay-3 {
+  animation-delay: 240ms;
+}
+.dashboard-section--delay-4 {
+  animation-delay: 320ms;
+}
+.dashboard-section--delay-5 {
+  animation-delay: 400ms;
+}
 
 @keyframes dashReveal {
   to {

--- a/src/pages/Dashbord/dashbord-Gerenciamento-Mensal.vue
+++ b/src/pages/Dashbord/dashbord-Gerenciamento-Mensal.vue
@@ -116,4 +116,12 @@ import DashboardRadialComposition from 'src/components/Dashbord/DashboardRadialC
     transform: translateY(0);
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .dashboard-section {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
 </style>


### PR DESCRIPTION
## Padronização das modais de configuração e redesign do filtro de período do dashboard

### 📋 Tipo de Alteração
- [x] ✨ Nova funcionalidade (feat)
- [ ] 🐛 Correção de bug (fix)
- [x] ♻️ Refatoração (refactor)
- [ ] ⚡ Melhoria de performance (perf)
- [ ] 🧪 Testes (test)
- [x] 📝 Documentação (docs)
- [ ] 🔧 Configuração/Tooling (chore)
- [x] 💅 Estilo/Formatação (style)
- [ ] 🔒 Segurança (security)

---

### 📝 Resumo

Esta branch unifica a experiência visual das telas de configuração (Conta, Categorias e Compartilhamento) com cabeçalhos padronizados e cards consistentes, e redesenha o filtro de período do dashboard para tornar o intervalo aplicado mais legível e os atalhos mais acessíveis. O período selecionado agora persiste na URL (`inicio`/`fim`), permitindo recarregar ou compartilhar o dashboard com o mesmo contexto. Também foram refinados o modal de compartilhamento, o seletor de contexto no mobile e pequenos ajustes de acessibilidade e responsividade.

---

### 🔄 O que foi alterado

#### Arquivos Adicionados
- `.specs/dashboard-period-filter/IMPLEMENTATION-PLAN.md` — plano de implementação do redesign do filtro de período
- `.specs/dashboard-period-filter/IMPLEMENTATION-STATE.md` — estado de conclusão das 3 fases do filtro
- `.specs/dashboard-period-filter/RELEASE-CHECKLIST.md` — checklist de release e evidências da persistência por URL
- `.specs/padronizacao-modais-config/IMPLEMENTATION-PLAN.md` — plano de padronização visual das modais de configuração
- `src/helpers/DashboardPeriodQuery.ts` — funções puras para parse, formatação e fallback de query params do período (`YYYY-MM`)

#### Arquivos Modificados

**Modais de configuração**
- `src/components/Configuracoes/InformacoesConta.vue` — cabeçalho padronizado (avatar 48px + nome/e-mail) e seções "Aparência" e "Notificações" encapsuladas em `q-card` com `rounded-borders-xl` e `shadow-1`
- `src/components/Configuracoes/CategoriaConfig.vue` — cabeçalho unificado, toolbar e tabela dentro de card; modal único de criar/editar categoria com grid de seleção de tipo; melhor contraste nas abas
- `src/components/Compartilhamento/CompartilhamentoConfig.vue` — títulos e descrições refinados nos cards de acesso; efeito hover nos cards
- `src/components/Configuracoes/ModalConfiguracoes.vue` — ajustes de padding do header no mobile; título exibido apenas em telas pequenas

**Compartilhamento**
- `src/components/Compartilhamento/CompartilhamentoModal.vue` — redesign completo com hierarquia visual, painel de convite, badges de status/permissão e layout responsivo (bottom sheet no mobile)
- `src/components/Compartilhamento/ContextoSelector.vue` — seletor convertido para `q-btn` com abertura nativa do `q-menu`; estilos responsivos para mobile
- `src/layouts/MainLayout.vue` — `ContextoSelector` visível também no mobile; toggle de tema movido para o menu do usuário em telas `xs`; `DateDisplay` oculto no mobile

**Dashboard — filtro de período**
- `src/components/Dashbord/SectionFiltrarPeriodo.vue` — redesign com divulgação progressiva: resumo do período aplicado, presets sempre visíveis com estado ativo, editor manual expansível (`Personalizar período` / `Fechar`), validação inline, suporte a `prefers-reduced-motion` e melhorias de acessibilidade (rótulos, `aria-*`, foco visível)
- `src/pages/Dashbord/dashbord-Gerenciamento-Mensal.vue` — sincronização bidirecional do período com query params via `DashboardPeriodQuery`; animações de entrada respeitam `prefers-reduced-motion`

**Outros**
- `src/components/Transacao/TransacaoBaseModal.vue` — ajuste visual do `q-select` de meta financeira (`filled`, `behavior="menu"`)

---

### 🧪 Como Testar

**Modais de configuração**
1. Abrir Configurações e alternar entre as abas Conta, Categorias e Compartilhamento.
2. Verificar cabeçalhos padronizados (avatar 48px + título + legenda) e cards com bordas arredondadas em light e dark mode.
3. Em Categorias: criar, editar e excluir uma categoria; validar o novo modal unificado e contraste das abas.
4. Em mobile (≤599px): confirmar que o modal rola corretamente e não há overflow horizontal.

**Compartilhamento**
1. Abrir o modal de compartilhamento e enviar um convite; verificar layout do painel de convite e lista de acessos.
2. No mobile, usar o seletor de contexto no header e trocar entre "Meus Dados" e contextos compartilhados.
3. Confirmar que o toggle de tema aparece no menu do usuário em telas pequenas.

**Filtro de período do dashboard**
1. Acessar o dashboard e verificar o resumo do período aplicado (ex.: "Junho de 2026").
2. Clicar em cada preset (`Mês atual`, `Últimos 3 meses`, `Este ano`) e confirmar estado ativo + atualização dos cards/gráficos.
3. Abrir `Personalizar período`, alterar campos, cancelar e confirmar restauração do período anterior.
4. Tentar aplicar intervalo inválido (início > fim) e verificar mensagem inline sem toast.
5. Aplicar um período customizado e confirmar que a URL atualiza para `?inicio=YYYY-MM&fim=YYYY-MM`.
6. Recarregar a página e navegar com back/forward — o período deve ser preservado.
7. Abrir URL com query inválida e confirmar fallback para o mês atual.
8. Testar em 320px, 768px e desktop; ativar `prefers-reduced-motion` e verificar ausência de animações.

**Build**
1. Executar `npm run lint` e `npm run build` — devem concluir sem erros.

---

### 🔗 Issues / Tickets Relacionados
_Nenhuma referência explícita nos commits._

---

### ⚠️ Pontos de Atenção para o Revisor

- **Sincronização URL ↔ store** (`dashbord-Gerenciamento-Mensal.vue`): os watchers comparam valores antes de chamar `setFiltros` e `router.replace` para evitar loops e consultas duplicadas — validar cenários de back/forward e URL compartilhada.
- **Contrato da store preservado**: `dashboardStore.setFiltros(mesInicial, anoInicial, mesFinal, anoFinal)` não foi alterado; cards e gráficos devem continuar reagindo normalmente.
- **Filtro de período**: presets nunca desaparecem (antes o atalho "Mês atual" sumia quando ativo); confirmar que o preset ativo é detectado corretamente em viradas de mês/ano.
- **Modal de categorias**: criação e edição foram unificadas em um único `q-dialog` — revisar fluxo de edição inline que antes usava `$q.dialog` prompt.
- **ContextoSelector no mobile**: agora sempre visível no header; verificar se não compete com outros elementos em telas muito estreitas (320px).
- **Smoke test autenticado pendente**: conforme `RELEASE-CHECKLIST.md`, a validação visual completa do dashboard autenticado não foi executada sem credenciais — recomenda-se testar em homologação antes do release.
