### PR TITLE
fix(despesas): Envie agrupadora na edição em lote

### DIFF
--- a/src/Model/Transacao.ts
+++ b/src/Model/Transacao.ts
@@ -69,6 +69,7 @@ export interface AtualizarLoteDespesaDTO {
   novoValor: number;
   novaDescricao: string;
   novaCategoriaId: string;
+  idDespesaAgrupadora?: string;
   modificador: ModificadorLote;
 }
 

--- a/src/pages/GerenciamentoMensal/DespesaPage.vue
+++ b/src/pages/GerenciamentoMensal/DespesaPage.vue
@@ -266,7 +266,7 @@ function abrirDialogModificadorLote(acao: string, transacao: DespesaResult): Pro
       cancel: true,
       persistent: true
     }).onOk((data: ModificadorLote) => {
-      resolve(data);
+      resolve(Number(data) as ModificadorLote);
     }).onCancel(() => {
       resolve(null);
     });
@@ -286,6 +286,7 @@ async function editar(despesaUpdate: DespesaCreate) {
       novoValor: Number(despesaUpdate.valor),
       novaDescricao: despesaUpdate.descricao,
       novaCategoriaId: despesaUpdate.categoriaId,
+      idDespesaAgrupadora: despesaUpdate.idDespesaAgrupadora ?? '',
       modificador: modificador
     };
 

--- a/src/services/transacao/DespesaService.ts
+++ b/src/services/transacao/DespesaService.ts
@@ -1,5 +1,6 @@
 import type { DespesaCreate, DespesaResult, LancarDespesaLoteDTO, AtualizarLoteDespesaDTO } from "src/Model/Transacao";
 import type { ModificadorLote } from "src/Model/Transacao";
+import { notificar } from "src/helpers/Notificacao";
 import TransacaoServiceBase from "../base/TransacaoBaseService";
 
 class DespesaService extends TransacaoServiceBase<DespesaCreate, DespesaResult> {
@@ -17,18 +18,21 @@ class DespesaService extends TransacaoServiceBase<DespesaCreate, DespesaResult> 
   async criarEmLote(dto: LancarDespesaLoteDTO) {
     return this.requestWithLoading(async () => {
       await this.axios.post(`${this.baseUrl}/lote`, dto);
+      notificar('Despesas geradas com sucesso!');
     });
   }
 
   async atualizarLote(id: string, dto: AtualizarLoteDespesaDTO) {
     return this.requestWithLoading(async () => {
       await this.axios.put(`${this.baseUrl}/${id}/lote`, dto);
+      notificar('Despesa(s) atualizada(s) com sucesso!');
     });
   }
 
   async excluirLote(id: string, modificador: ModificadorLote) {
     return this.requestWithLoading(async () => {
       await this.axios.delete(`${this.baseUrl}/${id}/lote/${modificador}`);
+      notificar('Despesa(s) excluída(s) com sucesso!');
     });
   }
 


### PR DESCRIPTION
Inclui a agrupadora selecionada no payload de edição de lotes e mostra notificações nas ações de lote para evitar feedback silencioso.